### PR TITLE
build(csproj): remove generatePackageOnBuild tag from csproj

### DIFF
--- a/APIMatic.Core/APIMatic.Core.csproj
+++ b/APIMatic.Core/APIMatic.Core.csproj
@@ -19,7 +19,6 @@
         <RepositoryType>git</RepositoryType>
         <PackageTags>APIMatic;dotnet;core;Core Library</PackageTags>
         <PackageProjectUrl>https://www.apimatic.io</PackageProjectUrl>
-        <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
         <PackageIcon>icon.png</PackageIcon>
     </PropertyGroup>
 


### PR DESCRIPTION
The following PR removes the generatePackageOnBuild tag from the csproj file. Removing this tag allows the don't pack command to run successfully on the core-lib project.

Closes #30