### PR TITLE
build(package): update referred packages to latest version

### DIFF
--- a/APIMatic.Core.Test/APIMatic.Core.Test.csproj
+++ b/APIMatic.Core.Test/APIMatic.Core.Test.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
         <PackageReference Include="coverlet.msbuild" Version="3.2.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/APIMatic.Core.Test/APIMatic.Core.Test.csproj
+++ b/APIMatic.Core.Test/APIMatic.Core.Test.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-        <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
+        <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/APIMatic.Core.Test/APIMatic.Core.Test.csproj
+++ b/APIMatic.Core.Test/APIMatic.Core.Test.csproj
@@ -7,17 +7,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
         <PackageReference Include="coverlet.msbuild" Version="3.2.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.48.0.56517">
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.51.0.59060">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
         <PackageReference Include="System.Net.Http.Json" Version="7.0.0" />
     </ItemGroup>

--- a/APIMatic.Core/APIMatic.Core.csproj
+++ b/APIMatic.Core/APIMatic.Core.csproj
@@ -37,7 +37,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="APIMatic.Core.Test" />

--- a/APIMatic.Core/APIMatic.Core.csproj
+++ b/APIMatic.Core/APIMatic.Core.csproj
@@ -30,14 +30,14 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-        <PackageReference Include="Microsoft.Json.Pointer" Version="2.2.0" />
-        <PackageReference Include="Polly" Version="7.2.1" />
-        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.48.0.56517">
+        <PackageReference Include="Microsoft.Json.Pointer" Version="2.3.0" />
+        <PackageReference Include="Polly" Version="7.2.3" />
+        <PackageReference Include="SonarAnalyzer.CSharp" Version="8.55.0.65544">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="APIMatic.Core.Test" />

--- a/APIMatic.Core/Types/VoidType.cs
+++ b/APIMatic.Core/Types/VoidType.cs
@@ -6,5 +6,5 @@ namespace APIMatic.Core.Types
     /// <summary>
     /// This represents the void ReturnType for API calls
     /// </summary>
-    public class VoidType { }
+    public interface VoidType { }
 }

--- a/APIMatic.Core/Utilities/TestHelper.cs
+++ b/APIMatic.Core/Utilities/TestHelper.cs
@@ -503,16 +503,7 @@ namespace APIMatic.Core.Utilities
 
         private static bool ListContainsJObject(JArray jArray)
         {
-            bool containsJObject = false;
-            foreach (var item in jArray)
-            {
-                if (item is JObject)
-                {
-                    containsJObject = true;
-                    break;
-                }
-            }
-            return containsJObject;
+            return jArray.Any(item => item is JObject);
         }
 
         private static bool IsArrayOfJObject(JArray jArray)

--- a/APIMatic.Core/Utilities/TestHelper.cs
+++ b/APIMatic.Core/Utilities/TestHelper.cs
@@ -508,16 +508,7 @@ namespace APIMatic.Core.Utilities
 
         private static bool IsArrayOfJObject(JArray jArray)
         {
-            bool listOfJObject = true;
-            foreach (var item in jArray)
-            {
-                if (!(item is JObject))
-                {
-                    listOfJObject = false;
-                    break;
-                }
-            }
-            return listOfJObject;
+            return jArray.All(item => item is JObject);
         }
     }
 }

--- a/APIMatic.Core/Utilities/XmlUtility.cs
+++ b/APIMatic.Core/Utilities/XmlUtility.cs
@@ -148,7 +148,7 @@ namespace APIMatic.Core.Utilities
 
             foreach (Match m in mc)
             {
-                val = m.Value.TrimStart('>').TrimEnd(new char[] { '<', '/' });
+                val = m.Value.TrimStart('>').TrimEnd('<', '/');
                 list.Add((T)Convert.ChangeType(val, typeof(T)));
             }
 


### PR DESCRIPTION
The following PR updates the referred external packages in the core-lib and core-lib test projects to make sure that the C# core-lib is up-to-date and has the latest fixes and improvements.

Packages updated in **APIMatic.Core**:

- Microsoft.Json.Pointer
- Polly
- SonarAnalyzer.CSharp
- System.Collections.Immutable

Packages updated in **APIMatic.Core.Test**:

- Microsoft.NET.Test.Sdk
- NUnit3TestAdapter
- SonarAnalyzer.CSharp