### PR TITLE
fix(request-builder): add null check in HeaderParam.Apply

### DIFF
--- a/APIMatic.Core/Request/Parameters/HeaderParam.cs
+++ b/APIMatic.Core/Request/Parameters/HeaderParam.cs
@@ -16,7 +16,7 @@ namespace APIMatic.Core.Request.Parameters
             {
                 return;
             }
-            requestBuilder.headers[key] = value.ToString();
+            requestBuilder.headers[key] = value?.ToString();
         }
     }
 }


### PR DESCRIPTION
The following PR fixes the NullReferenceException being thrown by the RequestBuilder with null header values from the API call. A null check has been added to make the Header value null which is handled gracefully in the HttpClientWrapper.

Closes #41