### PR TITLE
fix(http-client-wrapper): implement skipping SSL cert verification

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -179,6 +179,9 @@ dotnet_diagnostic.CA1310.severity = none
 # JSON002: Probable JSON string detected
 dotnet_diagnostic.JSON002.severity = none
 
+# S4830: Server certificates should be verified during SSL/TLS connection
+dotnet_diagnostic.S4830.severity = none
+
 [*.vb]
 ###############################
 # VB Coding Conventions       #

--- a/APIMatic.Core.Test/Http/CoreHttpClientConfigurationTest.cs
+++ b/APIMatic.Core.Test/Http/CoreHttpClientConfigurationTest.cs
@@ -22,6 +22,7 @@ namespace APIMatic.Core.Test.Http
         {
             // Arrange
             var timeout = 180;
+            var skipSslCertVerification = true;
             var numberOfRetries = 3;
             var backoffFactor = 3;
             var retryInterval = 4.5;
@@ -32,6 +33,7 @@ namespace APIMatic.Core.Test.Http
             // Act
             var config = _config.ToBuilder()
                 .Timeout(TimeSpan.FromSeconds(timeout))
+                .SkipSslCertVerification(skipSslCertVerification)
                 .NumberOfRetries(numberOfRetries)
                 .BackoffFactor(backoffFactor)
                 .RetryInterval(retryInterval)
@@ -43,6 +45,7 @@ namespace APIMatic.Core.Test.Http
             // Assert
             Assert.NotNull(config);
             Assert.AreEqual(config.Timeout, TimeSpan.FromSeconds(timeout));
+            Assert.AreEqual(config.SkipSslCertVerification, skipSslCertVerification);
             Assert.AreEqual(config.NumberOfRetries, numberOfRetries);
             Assert.AreEqual(config.BackoffFactor, backoffFactor);
             Assert.AreEqual(config.RetryInterval, retryInterval);
@@ -98,7 +101,7 @@ namespace APIMatic.Core.Test.Http
             var actual = _config.ToString();
 
             // Assert
-            var expected = "HttpClientConfiguration: 00:01:40 , 0 , 2 , 1 , 00:02:00 , System.Collections.Immutable.ImmutableList`1[System.Int32] , System.Collections.Immutable.ImmutableList`1[System.Net.Http.HttpMethod] , System.Net.Http.HttpClient , True ";
+            var expected = "HttpClientConfiguration: 00:01:40 , False , 0 , 2 , 1 , 00:02:00 , System.Collections.Immutable.ImmutableList`1[System.Int32] , System.Collections.Immutable.ImmutableList`1[System.Net.Http.HttpMethod] , System.Net.Http.HttpClient , True ";
             Assert.AreEqual(expected, actual);
         }
     }

--- a/APIMatic.Core.Test/Http/CoreHttpClientConfigurationTest.cs
+++ b/APIMatic.Core.Test/Http/CoreHttpClientConfigurationTest.cs
@@ -63,10 +63,12 @@ namespace APIMatic.Core.Test.Http
             var backoffFactor = 0;
             var retryInterval = -1;
             var maximumRetryWaitTime = -1;
+            var skipSslCertVerification = false;
 
             var config = _config.ToBuilder()
                 .HttpClientInstance(null)
                 .Timeout(TimeSpan.FromSeconds(timeout))
+                .SkipSslCertVerification(skipSslCertVerification)
                 .NumberOfRetries(numberOfRetries)
                 .BackoffFactor(backoffFactor)
                 .RetryInterval(retryInterval)
@@ -86,6 +88,7 @@ namespace APIMatic.Core.Test.Http
             Assert.NotNull(config);
             Assert.NotNull(config.HttpClientInstance);
             Assert.AreEqual(config.Timeout, TimeSpan.FromSeconds(defaultTimeout));
+            Assert.AreEqual(config.SkipSslCertVerification, skipSslCertVerification);
             Assert.AreEqual(config.NumberOfRetries, defaultNumberOfRetries);
             Assert.AreEqual(config.BackoffFactor, defaultBackoffFactor);
             Assert.AreEqual(config.RetryInterval, defaultRetryInterval);

--- a/APIMatic.Core.Test/Http/HttpClientWrapperSSLTest.cs
+++ b/APIMatic.Core.Test/Http/HttpClientWrapperSSLTest.cs
@@ -16,6 +16,7 @@ namespace APIMatic.Core.Test.Http
         [Test]
         public void TestHttpClientSSLCertificateVerification_ExceptionResponse()
         {
+            var expectedValue = "The SSL connection could not be established, see inner exception.";
             var clientConfiguration = new CoreHttpClientConfiguration.Builder()
                 .Build();
 
@@ -36,7 +37,7 @@ namespace APIMatic.Core.Test.Http
 
             // Act
             var ex = Assert.ThrowsAsync<HttpRequestException>(() => client.ExecuteAsync(request));
-            Assert.AreEqual(ex.Message, "The SSL connection could not be established, see inner exception.");
+            Assert.AreEqual(expectedValue, ex.Message);
         }
 
         [Test]

--- a/APIMatic.Core.Test/Http/HttpClientWrapperSSLTest.cs
+++ b/APIMatic.Core.Test/Http/HttpClientWrapperSSLTest.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using APIMatic.Core.Http.Configuration;
+using NUnit.Framework;
+
+namespace APIMatic.Core.Test.Http
+{
+    [TestFixture]
+    public class HttpClientWrapperSSLTest : TestBase
+    {
+        private readonly string expiredSSLCertUrl = "https://expired.badssl.com/";
+
+        [Test]
+        public void TestHttpClientSSLCertificateVerification_ExceptionResponse()
+        {
+            var clientConfiguration = new CoreHttpClientConfiguration.Builder()
+                .Build();
+
+            var config = new GlobalConfiguration.Builder()
+                .ServerUrls(new Dictionary<Enum, string>
+                {
+                    { MockServer.Server1, expiredSSLCertUrl },
+                }, MockServer.Server1)
+                .HttpConfiguration(clientConfiguration)
+                .ApiCallback(ApiCallBack)
+                .Build();
+
+            var client = config.HttpClient;
+
+            var request = config.GlobalRequestBuilder()
+                .Setup(HttpMethod.Get, string.Empty)
+                .Build();
+
+            // Act
+            var ex = Assert.ThrowsAsync<HttpRequestException>(() => client.ExecuteAsync(request));
+            Assert.AreEqual(ex.Message, "The SSL connection could not be established, see inner exception.");
+        }
+
+        [Test]
+        public async Task TestHttpClientSkipSSLCertificateVerification_OKResponse()
+        {
+            var clientConfiguration = new CoreHttpClientConfiguration.Builder()
+                .SkipSslCertVerification(true)
+                .Build();
+
+            var config = new GlobalConfiguration.Builder()
+                .ServerUrls(new Dictionary<Enum, string>
+                {
+                    { MockServer.Server1, expiredSSLCertUrl },
+                }, MockServer.Server1)
+                .HttpConfiguration(clientConfiguration)
+                .ApiCallback(ApiCallBack)
+                .Build();
+
+            var client = config.HttpClient;
+
+            var request = config.GlobalRequestBuilder()
+                .Setup(HttpMethod.Get, string.Empty)
+                .Build();
+
+            // Act
+            var actual = await client.ExecuteAsync(request);
+
+            Assert.AreEqual(actual.StatusCode, (int)HttpStatusCode.OK);
+        }
+    }
+}

--- a/APIMatic.Core.Test/TestBase.cs
+++ b/APIMatic.Core.Test/TestBase.cs
@@ -25,6 +25,7 @@ namespace APIMatic.Core.Test
         private static readonly ICoreHttpClientConfiguration _clientConfiguration = new CoreHttpClientConfiguration.Builder()
             .HttpClientInstance(new HttpClient(handlerMock))
             .NumberOfRetries(numberOfRetries)
+            .SkipSslCertVerification(false)
             .Build();
 
         private static readonly BasicAuthManager _basicAuthManager = new(_basicAuthUserName, _basicAuthPassword);

--- a/APIMatic.Core.Test/TestBase.cs
+++ b/APIMatic.Core.Test/TestBase.cs
@@ -25,7 +25,6 @@ namespace APIMatic.Core.Test
         private static readonly ICoreHttpClientConfiguration _clientConfiguration = new CoreHttpClientConfiguration.Builder()
             .HttpClientInstance(new HttpClient(handlerMock))
             .NumberOfRetries(numberOfRetries)
-            .SkipSslCertVerification(false)
             .Build();
 
         private static readonly BasicAuthManager _basicAuthManager = new(_basicAuthUserName, _basicAuthPassword);

--- a/APIMatic.Core/Http/Configuration/CoreHttpClientConfiguration.cs
+++ b/APIMatic.Core/Http/Configuration/CoreHttpClientConfiguration.cs
@@ -261,21 +261,14 @@ namespace APIMatic.Core.Http.Configuration
                 {
                     if (skipSslCertVerification)
                     {
-                        var httpClientHandler = new HttpClientHandler
-                        {
-                            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; }
-                        };
-
-                        httpClientInstance = new HttpClient(httpClientHandler, disposeHandler: true);
+                        httpClientInstance = GetOverriddenSSLCertVerificationHttpClient();
                     }
                     else
                     {
                         httpClientInstance = httpClientInstance ?? new HttpClient();
                     }
-
                     httpClientInstance.Timeout = timeout;
                 }
-
                 return new CoreHttpClientConfiguration(
                         timeout,
                         skipSslCertVerification,
@@ -287,6 +280,15 @@ namespace APIMatic.Core.Http.Configuration
                         requestMethodsToRetry,
                         httpClientInstance ?? new HttpClient(),
                         overrideHttpClientConfiguration);
+            }
+
+            private HttpClient GetOverriddenSSLCertVerificationHttpClient()
+            {
+                var httpClientHandler = new HttpClientHandler
+                {
+                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; }
+                };
+                return new HttpClient(httpClientHandler, disposeHandler: true);
             }
         }
     }

--- a/APIMatic.Core/Http/Configuration/CoreHttpClientConfiguration.cs
+++ b/APIMatic.Core/Http/Configuration/CoreHttpClientConfiguration.cs
@@ -257,7 +257,6 @@ namespace APIMatic.Core.Http.Configuration
             /// <returns>HttpClientConfiguration.</returns>
             public CoreHttpClientConfiguration Build()
             {
-                httpClientInstance = GetInitializedHttpClientInstance();
                 return new CoreHttpClientConfiguration(
                         timeout,
                         skipSslCertVerification,
@@ -267,7 +266,7 @@ namespace APIMatic.Core.Http.Configuration
                         maximumRetryWaitTime,
                         statusCodesToRetry,
                         requestMethodsToRetry,
-                        httpClientInstance,
+                        GetInitializedHttpClientInstance(),
                         overrideHttpClientConfiguration);
             }
 

--- a/APIMatic.Core/Http/Configuration/CoreHttpClientConfiguration.cs
+++ b/APIMatic.Core/Http/Configuration/CoreHttpClientConfiguration.cs
@@ -246,7 +246,7 @@ namespace APIMatic.Core.Http.Configuration
             /// <returns>Builder.</returns>
             public Builder HttpClientInstance(HttpClient httpClientInstance, bool overrideHttpClientConfiguration = true)
             {
-                this.httpClientInstance = httpClientInstance ?? new HttpClient();
+                this.httpClientInstance = httpClientInstance;
                 this.overrideHttpClientConfiguration = overrideHttpClientConfiguration;
                 return this;
             }
@@ -257,6 +257,25 @@ namespace APIMatic.Core.Http.Configuration
             /// <returns>HttpClientConfiguration.</returns>
             public CoreHttpClientConfiguration Build()
             {
+                if (overrideHttpClientConfiguration)
+                {
+                    if (skipSslCertVerification)
+                    {
+                        var httpClientHandler = new HttpClientHandler
+                        {
+                            ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; }
+                        };
+
+                        httpClientInstance = new HttpClient(httpClientHandler, disposeHandler: true);
+                    }
+                    else
+                    {
+                        httpClientInstance = httpClientInstance ?? new HttpClient();
+                    }
+
+                    httpClientInstance.Timeout = timeout;
+                }
+
                 return new CoreHttpClientConfiguration(
                         timeout,
                         skipSslCertVerification,
@@ -266,7 +285,7 @@ namespace APIMatic.Core.Http.Configuration
                         maximumRetryWaitTime,
                         statusCodesToRetry,
                         requestMethodsToRetry,
-                        httpClientInstance,
+                        httpClientInstance ?? new HttpClient(),
                         overrideHttpClientConfiguration);
             }
         }

--- a/APIMatic.Core/Http/Configuration/CoreHttpClientConfiguration.cs
+++ b/APIMatic.Core/Http/Configuration/CoreHttpClientConfiguration.cs
@@ -20,6 +20,7 @@ namespace APIMatic.Core.Http.Configuration
         /// </summary>
         private CoreHttpClientConfiguration(
             TimeSpan timeout,
+            bool skipSslCertVerification,
             int numberOfRetries,
             int backoffFactor,
             double retryInterval,
@@ -30,6 +31,7 @@ namespace APIMatic.Core.Http.Configuration
             bool overrideHttpClientConfiguration)
         {
             Timeout = timeout;
+            SkipSslCertVerification = skipSslCertVerification;
             NumberOfRetries = numberOfRetries;
             BackoffFactor = backoffFactor;
             RetryInterval = retryInterval;
@@ -44,6 +46,11 @@ namespace APIMatic.Core.Http.Configuration
         /// Gets Http client timeout.
         /// </summary>
         public TimeSpan Timeout { get; }
+
+        /// <summary>
+        /// Gets Whether to skip verification of SSL certificates.
+        /// </summary>
+        public bool SkipSslCertVerification { get; }
 
         /// <summary>
         /// Gets Number of times the request is retried.
@@ -90,6 +97,7 @@ namespace APIMatic.Core.Http.Configuration
         {
             return "HttpClientConfiguration: " +
                 $"{Timeout} , " +
+                $"{SkipSslCertVerification} , " +
                 $"{NumberOfRetries} , " +
                 $"{BackoffFactor} , " +
                 $"{RetryInterval} , " +
@@ -108,6 +116,7 @@ namespace APIMatic.Core.Http.Configuration
         {
             var builder = new Builder()
                 .Timeout(Timeout)
+                .SkipSslCertVerification(SkipSslCertVerification)
                 .NumberOfRetries(NumberOfRetries)
                 .BackoffFactor(BackoffFactor)
                 .RetryInterval(RetryInterval)
@@ -125,6 +134,7 @@ namespace APIMatic.Core.Http.Configuration
         public class Builder
         {
             private TimeSpan timeout = TimeSpan.FromSeconds(100);
+            private bool skipSslCertVerification = false;
             private int numberOfRetries = 0;
             private int backoffFactor = 2;
             private double retryInterval = 1;
@@ -148,6 +158,17 @@ namespace APIMatic.Core.Http.Configuration
             public Builder Timeout(TimeSpan timeout)
             {
                 this.timeout = timeout.TotalSeconds <= 0 ? TimeSpan.FromSeconds(100) : timeout;
+                return this;
+            }
+
+            /// <summary>
+            /// Sets the SkipSslCertVerification.
+            /// </summary>
+            /// <param name="skipSslCertVerification">Bool for skipping (or not) SSL certificate verification</param>
+            /// <returns>Builder.</returns>
+            public Builder SkipSslCertVerification(bool skipSslCertVerification)
+            {
+                this.skipSslCertVerification = skipSslCertVerification;
                 return this;
             }
 
@@ -238,6 +259,7 @@ namespace APIMatic.Core.Http.Configuration
             {
                 return new CoreHttpClientConfiguration(
                         timeout,
+                        skipSslCertVerification,
                         numberOfRetries,
                         backoffFactor,
                         retryInterval,

--- a/APIMatic.Core/Http/Configuration/ICoreHttpClientConfiguration.cs
+++ b/APIMatic.Core/Http/Configuration/ICoreHttpClientConfiguration.cs
@@ -18,6 +18,11 @@ namespace APIMatic.Core.Http.Configuration
         TimeSpan Timeout { get; }
 
         /// <summary>
+        /// Gets Whether to skip verification of SSL certificates.
+        /// </summary>
+        bool SkipSslCertVerification { get; }
+
+        /// <summary>
         /// Number of times the request is retried.
         /// </summary>
         int NumberOfRetries { get; }

--- a/APIMatic.Core/Http/HttpClientWrapper.cs
+++ b/APIMatic.Core/Http/HttpClientWrapper.cs
@@ -63,7 +63,11 @@ namespace APIMatic.Core.Http
 
             if (httpClientConfig.SkipSslCertVerification)
             {
-                var httpClientHandler = new HttpClientHandler();
+                var httpClientHandler = new HttpClientHandler
+                {
+                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; }
+                };
+
                 _client = new HttpClient(httpClientHandler, disposeHandler: true);
             }
         }

--- a/APIMatic.Core/Http/HttpClientWrapper.cs
+++ b/APIMatic.Core/Http/HttpClientWrapper.cs
@@ -60,6 +60,12 @@ namespace APIMatic.Core.Http
                 _maximumRetryWaitTime = httpClientConfig.MaximumRetryWaitTime;
                 _client.Timeout = httpClientConfig.Timeout;
             }
+
+            if (httpClientConfig.SkipSslCertVerification)
+            {
+                var httpClientHandler = new HttpClientHandler();
+                _client = new HttpClient(httpClientHandler, disposeHandler: true);
+            }
         }
 
         /// <summary>
@@ -292,7 +298,6 @@ namespace APIMatic.Core.Http
         {
             double noise = new Random().NextDouble() * 100;
             return (1000 * _retryInterval * Math.Pow(_backoffFactor, retryAttempt - 1)) + noise;
-
         }
 
         private static Dictionary<string, string> GetCombinedResponseHeaders(HttpResponseMessage responseMessage)

--- a/APIMatic.Core/Http/HttpClientWrapper.cs
+++ b/APIMatic.Core/Http/HttpClientWrapper.cs
@@ -58,17 +58,6 @@ namespace APIMatic.Core.Http
                 _backoffFactor = httpClientConfig.BackoffFactor;
                 _retryInterval = httpClientConfig.RetryInterval;
                 _maximumRetryWaitTime = httpClientConfig.MaximumRetryWaitTime;
-                _client.Timeout = httpClientConfig.Timeout;
-            }
-
-            if (httpClientConfig.SkipSslCertVerification)
-            {
-                var httpClientHandler = new HttpClientHandler
-                {
-                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => { return true; }
-                };
-
-                _client = new HttpClient(httpClientHandler, disposeHandler: true);
             }
         }
 


### PR DESCRIPTION
Adds implementation for skipping SSL cert verification to HttpClientConfiguration and HttpClientWrapper.

Closes #43 