### PR TITLE
fix(number-enum-deserialization): added fixes for nullable enum deserialization with valid values

### DIFF
--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -151,6 +151,40 @@ namespace APIMatic.Core.Test.Utilities
             Assert.AreEqual(expected, actual);
         }
 
+        [Test]
+        public void JsonDeserialize_EnumString()
+        {
+            var actualNullable = CoreHelper.JsonDeserialize<WorkingDays?>("\"Monday\"");
+            Assert.AreEqual(WorkingDays.Monday, actualNullable);
+
+            var actual = CoreHelper.JsonDeserialize<WorkingDays>("\"Monday\"");
+            Assert.AreEqual(WorkingDays.Monday, actual);
+        }
+
+        [Test]
+        public void JsonDeserialize_EnumStringNullable()
+        {
+            var actual = CoreHelper.JsonDeserialize<WorkingDays?>("null");
+            Assert.AreEqual(null, actual);
+        }
+
+        [Test]
+        public void JsonDeserialize_EnumNumber()
+        {
+            var actualNullable = CoreHelper.JsonDeserialize<MonthNumber?>("3");
+            Assert.AreEqual(MonthNumber.March, actualNullable);
+
+            var actual = CoreHelper.JsonDeserialize<MonthNumber>("3");
+            Assert.AreEqual(MonthNumber.March, actual);
+        }
+
+        [Test]
+        public void JsonDeserialize_EnumNumberNullable()
+        {
+            var actual = CoreHelper.JsonDeserialize<MonthNumber?>("null");
+            Assert.AreEqual(null, actual);
+        }
+
         #endregion
 
         #region AppendQueryParameters


### PR DESCRIPTION
## What
This PR added a fix for the bug where the NumberEnumConverter throws unable to convert exception when trying to convert a valid enum value to a Nullable Enum

## Why
We need to cover such edge cases to make the SDKs unbreakable

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
