### PR TITLE
fix(bool-serialization-query): prefered `true` as the serializable bool value for query

### DIFF
--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -457,7 +457,7 @@ namespace APIMatic.Core.Test.Utilities
                 "serverResponse"
             };
 
-            string expected = $"{SERVER_URL}?serverResponse%5Bpassed%5D=True";
+            string expected = $"{SERVER_URL}?serverResponse%5Bpassed%5D=true";
             CoreHelper.AppendUrlWithQueryParameters(queryBuilder, GetParameters(parametersKeys, serverResponse));
             string actual = queryBuilder.ToString();
             Assert.AreEqual(expected, actual);
@@ -626,7 +626,7 @@ namespace APIMatic.Core.Test.Utilities
                 "serverResponse"
             };
 
-            string expected = $"{SERVER_URL}?serverResponse%5B0%5D%5Bpassed%5D=True";
+            string expected = $"{SERVER_URL}?serverResponse%5B0%5D%5Bpassed%5D=true";
             CoreHelper.AppendUrlWithQueryParameters(queryBuilder, GetParameters(parametersKeys, stringCollection));
             string actual = queryBuilder.ToString();
             Assert.AreEqual(expected, actual);

--- a/APIMatic.Core/Utilities/CoreHelper.cs
+++ b/APIMatic.Core/Utilities/CoreHelper.cs
@@ -519,20 +519,21 @@ namespace APIMatic.Core.Utilities
 
         private static string GetElementValue(object element, bool urlEncode)
         {
-            string elemValue;
             if (element is DateTime time)
             {
-                elemValue = time.ToString(DateTimeFormat);
-                return elemValue;
+                return time.ToString(DateTimeFormat);
             }
-            else if (element is DateTimeOffset offset)
+
+            if (element is DateTimeOffset offset)
             {
-                elemValue = offset.ToString(DateTimeFormat);
-                return elemValue;
+                return offset.ToString(DateTimeFormat);
             }
-            else
+
+            string elemValue = element.ToString();
+
+            if (element is bool)
             {
-                elemValue = element.ToString();
+                elemValue = elemValue.ToLower();
             }
 
             if (urlEncode)


### PR DESCRIPTION
## What
This PR fixes a bug where we were serializing the boolean values as `True` and `False` instead of `true` and `false` while sending them in query string

## Why
Although the query parameter values are case insensitive, but we need to make sure that the serialization across our tooling remain same

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
