### PR TITLE
fix(or-multiple-auth): applying only the first available auth for OR cases

### DIFF
--- a/APIMatic.Core.Test/AuthenticationTest.cs
+++ b/APIMatic.Core.Test/AuthenticationTest.cs
@@ -11,7 +11,40 @@ namespace APIMatic.Core.Test
     public class AuthenticationTest : TestBase
     {
         [Test]
-        public void Multiple_Authentication_Success()
+        public void Multiple_Authentication_Success_WithFirstAuth()
+        {
+            var globalConfiguration = new GlobalConfiguration.Builder()
+                .ServerUrls(new Dictionary<Enum, string>
+                {
+                    {MockServer.Server1, "http://my/path:3000/{one}"},
+                }, MockServer.Server1)
+                .AuthManagers(new Dictionary<string, AuthManager>()
+                {
+                    {"basic", new BasicAuthManager("username", "password")},
+                    {"header", new HeaderAuthManager("my api key", "test token")},
+                    {"query", new QueryAuthManager("my api key", "test token")}
+                })
+                .HttpConfiguration(_clientConfiguration)
+                .Build();
+
+            var request = globalConfiguration.GlobalRequestBuilder()
+                .Setup(HttpMethod.Get, "/auth")
+                .WithOrAuth(auth => auth
+                    .AddAndGroup(innerGroup => innerGroup
+                        .Add("header")
+                        .Add("query"))
+                    .Add("basic"))
+                .Build();
+
+            Assert.False(request.Headers.ContainsKey("Authorization"));
+            Assert.AreEqual("my api key", request.Headers["API-KEY"]);
+            Assert.AreEqual("test token", request.Headers["TOKEN"]);
+            Assert.AreEqual("my api key", request.QueryParameters["API-KEY"]);
+            Assert.AreEqual("test token", request.QueryParameters["TOKEN"]);
+        }
+
+        [Test]
+        public void Multiple_Authentication_Success_WithSecondAuth()
         {
             var basicAuthManager = new BasicAuthManager("username", "password");
             var globalConfiguration = new GlobalConfiguration.Builder()
@@ -22,7 +55,7 @@ namespace APIMatic.Core.Test
                 .AuthManagers(new Dictionary<string, AuthManager>()
                 {
                     {"basic", basicAuthManager},
-                    {"header", new HeaderAuthManager("my api key", "test token")},
+                    {"header", new HeaderAuthManager(null, null)},
                     {"query", new QueryAuthManager("my api key", "test token")}
                 })
                 .HttpConfiguration(_clientConfiguration)
@@ -31,17 +64,17 @@ namespace APIMatic.Core.Test
             var request = globalConfiguration.GlobalRequestBuilder()
                 .Setup(HttpMethod.Get, "/auth")
                 .WithOrAuth(auth => auth
-                    .Add("basic")
                     .AddAndGroup(innerGroup => innerGroup
                         .Add("header")
-                        .Add("query")))
+                        .Add("query"))
+                    .Add("basic"))
                 .Build();
 
             Assert.AreEqual(basicAuthManager.GetBasicAuthHeader(), request.Headers["Authorization"]);
-            Assert.AreEqual("my api key", request.Headers["API-KEY"]);
-            Assert.AreEqual("test token", request.Headers["TOKEN"]);
-            Assert.AreEqual("my api key", request.QueryParameters["API-KEY"]);
-            Assert.AreEqual("test token", request.QueryParameters["TOKEN"]);
+            Assert.False(request.Headers.ContainsKey("API-KEY"));
+            Assert.False(request.Headers.ContainsKey("TOKEN"));
+            Assert.False(request.Headers.ContainsKey("API-KEY"));
+            Assert.False(request.Headers.ContainsKey("TOKEN"));
         }
 
         [Test]

--- a/APIMatic.Core.Test/AuthenticationTest.cs
+++ b/APIMatic.Core.Test/AuthenticationTest.cs
@@ -74,8 +74,8 @@ namespace APIMatic.Core.Test
             Assert.AreEqual(basicAuthManager.GetBasicAuthHeader(), request.Headers["Authorization"]);
             Assert.False(request.Headers.ContainsKey("API-KEY"));
             Assert.False(request.Headers.ContainsKey("TOKEN"));
-            Assert.False(request.Headers.ContainsKey("API-KEY"));
-            Assert.False(request.Headers.ContainsKey("TOKEN"));
+            Assert.False(request.QueryParameters.ContainsKey("API-KEY"));
+            Assert.False(request.QueryParameters.ContainsKey("TOKEN"));
         }
 
         [Test]

--- a/APIMatic.Core.Test/AuthenticationTest.cs
+++ b/APIMatic.Core.Test/AuthenticationTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net.Http;
 using APIMatic.Core.Authentication;
 using APIMatic.Core.Test.MockTypes.Authentication;
+using APIMatic.Core.Types.Sdk.Exceptions;
 using NUnit.Framework;
 
 namespace APIMatic.Core.Test
@@ -94,7 +95,7 @@ namespace APIMatic.Core.Test
                 .HttpConfiguration(_clientConfiguration)
                 .Build();
 
-            var exp = Assert.Throws<ArgumentNullException>(() => globalConfiguration.GlobalRequestBuilder()
+            var exp = Assert.Throws<AuthValidationException>(() => globalConfiguration.GlobalRequestBuilder()
                 .Setup(HttpMethod.Get, "/auth")
                 .WithOrAuth(auth => auth
                     .Add("basic")
@@ -125,7 +126,7 @@ namespace APIMatic.Core.Test
                 .HttpConfiguration(_clientConfiguration)
                 .Build();
 
-            var exp = Assert.Throws<ArgumentNullException>(() => globalConfiguration.GlobalRequestBuilder()
+            var exp = Assert.Throws<AuthValidationException>(() => globalConfiguration.GlobalRequestBuilder()
                 .Setup(HttpMethod.Get, "/auth")
                 .WithAndAuth(auth => auth
                     .Add("query")
@@ -152,7 +153,7 @@ namespace APIMatic.Core.Test
                 .HttpConfiguration(_clientConfiguration)
                 .Build();
 
-            var exp = Assert.Throws<ArgumentNullException>(() => globalConfiguration.GlobalRequestBuilder()
+            var exp = Assert.Throws<AuthValidationException>(() => globalConfiguration.GlobalRequestBuilder()
                 .Setup(HttpMethod.Get, "/auth")
                 .WithAndAuth(auth => auth
                     .Add("query")
@@ -183,7 +184,7 @@ namespace APIMatic.Core.Test
                 .HttpConfiguration(_clientConfiguration)
                 .Build();
 
-            var exp = Assert.Throws<ArgumentNullException>(() => globalConfiguration.GlobalRequestBuilder()
+            var exp = Assert.Throws<AuthValidationException>(() => globalConfiguration.GlobalRequestBuilder()
                 .Setup(HttpMethod.Get, "/auth")
                 .WithAndAuth(auth => auth
                     .Add("query")

--- a/APIMatic.Core/Authentication/AuthGroupBuilder.cs
+++ b/APIMatic.Core/Authentication/AuthGroupBuilder.cs
@@ -83,6 +83,11 @@ namespace APIMatic.Core.Authentication
                 try
                 {
                     authManager.Apply(requestBuilder);
+                    if (!isAndGroup)
+                    {
+                        // return early if any authentication in OR group gets applied
+                        return;
+                    }
                 }
                 catch (ArgumentNullException ex)
                 {
@@ -90,10 +95,9 @@ namespace APIMatic.Core.Authentication
                 }
             }
 
-            if (errors.Any() && (errors.Count == authManagers.Count || isAndGroup))
+            if (errors.Any())
             {
-                // throw exception if unable to apply All authentications in OR group
-                // OR if unable to apply Any Single authentication in AND group
+                // throw exception if unable to apply Any Single authentication in AND group
                 var messagePrefix = $"Following authentication credentials are required:\n-> ";
                 throw new ArgumentNullException(null, messagePrefix + string.Join("\n-> ", errors.Select(e => e.TrimStart(messagePrefix.ToCharArray()))));
             }

--- a/APIMatic.Core/Authentication/AuthGroupBuilder.cs
+++ b/APIMatic.Core/Authentication/AuthGroupBuilder.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using APIMatic.Core.Request;
+using APIMatic.Core.Types.Sdk.Exceptions;
 
 namespace APIMatic.Core.Authentication
 {
@@ -98,8 +99,8 @@ namespace APIMatic.Core.Authentication
             if (errors.Any())
             {
                 // throw exception if unable to apply Any Single authentication in AND group
-                var messagePrefix = $"Following authentication credentials are required:\n-> ";
-                throw new ArgumentNullException(null, messagePrefix + string.Join("\n-> ", errors.Select(e => e.TrimStart(messagePrefix.ToCharArray()))));
+                // OR if unable to apply All authentication in OR group
+                throw new AuthValidationException(errors);
             }
         }
     }

--- a/APIMatic.Core/Types/Sdk/Exceptions/AuthValidationException.cs
+++ b/APIMatic.Core/Types/Sdk/Exceptions/AuthValidationException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace APIMatic.Core.Types.Sdk.Exceptions
+{
+    public class AuthValidationException : ArgumentNullException
+    {
+        private const string ErrorMessagePrefix = "Following authentication credentials are required:\n-> ";
+
+        public AuthValidationException(List<string> errors)
+            : base(null, ErrorMessagePrefix + string.Join("\n-> ", errors.Select(e => e.TrimStart(ErrorMessagePrefix.ToCharArray()))))
+        {
+        }
+    }
+
+}


### PR DESCRIPTION
## What
This PR fixes a bug for multipleAuth's combination `Auth1 OR Auth2` where both authentications Auth1 and Auth2 are being applied. Instead, we need to apply either Auth1 or Auth2 to the request for such cases.

## Why
We needed to fix the OR auth applying functionality

Closes #56 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
