### PR TITLE
fix(oneof-anyof-nulls): added fix for deserializing null values to oaf containers

### DIFF
--- a/APIMatic.Core.Test/Utilities/OneOfContainerTest.cs
+++ b/APIMatic.Core.Test/Utilities/OneOfContainerTest.cs
@@ -79,6 +79,14 @@ namespace APIMatic.Core.Test.Utilities
         }
 
         [Test]
+        public void TestNativeTypeWithNullValue()
+        {
+            NativeOneOfContainer container = CoreHelper.JsonDeserialize<NativeOneOfContainer>("null");
+
+            Assert.IsNull(container);
+        }
+
+        [Test]
         public void TestNativeNullableType()
         {
             NativeNullableOneOfContainer container = CoreHelper.JsonDeserialize<NativeNullableOneOfContainer>("null");

--- a/APIMatic.Core/Utilities/Converters/UnionTypeConverter.cs
+++ b/APIMatic.Core/Utilities/Converters/UnionTypeConverter.cs
@@ -79,6 +79,12 @@ namespace APIMatic.Core.Utilities.Converters
                 return mappedValues[0].value;
             }
 
+            if (token.Type == JTokenType.Null)
+            {
+                // allow null values to pass as the OAF containers are nullable by default
+                return default;
+            }
+
             if (_isOneOf)
             {
                 throw new OneOfValidationException(unMappedTypes, token.ToString());


### PR DESCRIPTION
## What
This PR added support for the null values to pass while deserialization if none of the inner types are matched as the OAF containers are nullable by default

## Why
We were required to resolve a critical deserialization issue

Closes #58 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
