### PR TITLE
fix(serialization): stack overflow in JsonStringConverter

### DIFF
--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -7,6 +7,7 @@ using APIMatic.Core.Http.Configuration;
 using APIMatic.Core.Test.MockTypes.Models;
 using APIMatic.Core.Test.MockTypes.Utilities;
 using APIMatic.Core.Utilities;
+using APIMatic.Core.Utilities.Converters;
 using APIMatic.Core.Utilities.Date;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -105,6 +106,15 @@ namespace APIMatic.Core.Test.Utilities
             string expected = "[\"Thu, 12 Apr 2018 00:00:00 GMT\"]";
             string actual = CoreHelper.JsonSerialize(list, new CoreCustomDateTimeConverter("r"));
             Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void JsonSerialize_JsonString()
+        {
+            string str = "a";
+            string expected = "\"a\"";
+            var actual = CoreHelper.JsonSerialize(str, new JsonStringConverter());
+            Assert.That(actual, Is.EquivalentTo(expected));
         }
 
         #endregion

--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -117,6 +117,15 @@ namespace APIMatic.Core.Test.Utilities
             Assert.That(actual, Is.EquivalentTo(expected));
         }
 
+        [Test]
+        public void JsonSerialize_JsonString_NotAString()
+        {
+            int number = 24;
+            string expected = "24";
+            var actual = CoreHelper.JsonSerialize(number, new JsonStringConverter());
+            Assert.That(actual, Is.EquivalentTo(expected));
+        }
+
         #endregion
 
         #region Deserialize

--- a/APIMatic.Core/Utilities/Converters/JsonStringConverter.cs
+++ b/APIMatic.Core/Utilities/Converters/JsonStringConverter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace APIMatic.Core.Utilities.Converters
 {
@@ -32,8 +33,17 @@ namespace APIMatic.Core.Utilities.Converters
             return null;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) =>
-            serializer.Serialize(writer, value);
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) 
+        {
+            JToken token = JToken.FromObject(value);
+
+            if (token.Type == JTokenType.String)
+            {
+                JValue val = (JValue)token;
+
+                val.WriteTo(writer);
+            }
+        }
     }
 
 }

--- a/APIMatic.Core/Utilities/Converters/JsonStringConverter.cs
+++ b/APIMatic.Core/Utilities/Converters/JsonStringConverter.cs
@@ -33,7 +33,7 @@ namespace APIMatic.Core.Utilities.Converters
             return null;
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer) 
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
             JToken token = JToken.FromObject(value);
 


### PR DESCRIPTION
## What
This PR makes the `JsonStringConverter` class write directly to the `JsonWriter` instead of delegating to the serializer.

## Why
Previous delegation of serialization to the serializer resulted in a stack overflow where Newtonsoft.JSON external code called our `WriteJson` and our `WriteJson` called Newtonsoft.JSON external code. The serializer in the arguments of `WriteJson` is a reference to the [calling serializer](https://www.newtonsoft.com/json/help/html/M_Newtonsoft_Json_JsonConverter_WriteJson.htm) which is why it resulted in a stack overflow.

Closes #60 

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
I have tested this by trying the new unit test.

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
