### PR TITLE
feat(enums): relaxing enum validation at deserialization

### DIFF
--- a/APIMatic.Core.Test/MockTypes/Models/MonthNumber.cs
+++ b/APIMatic.Core.Test/MockTypes/Models/MonthNumber.cs
@@ -19,4 +19,22 @@ namespace APIMatic.Core.Test.MockTypes.Models
         November = 11,
         December = 12
     }
+
+    [JsonConverter(typeof(UnknownEnumConverter<NumberEnumConverter>), nameof(_Unknown))]
+    public enum MonthNumberAllowAdditionalValues
+    {
+        January = 1,
+        February = 2,
+        March = 3,
+        April = 4,
+        May = 5,
+        June = 6,
+        July = 7,
+        August = 8,
+        September = 9,
+        October = 10,
+        November = 11,
+        December = 12,
+        _Unknown
+    }
 }

--- a/APIMatic.Core.Test/MockTypes/Models/WorkingDays.cs
+++ b/APIMatic.Core.Test/MockTypes/Models/WorkingDays.cs
@@ -12,4 +12,15 @@ namespace APIMatic.Core.Test.MockTypes.Models
         Thursday,
         Friday
     }
+
+    [JsonConverter(typeof(UnknownEnumConverter<StringEnumConverter>), nameof(_Unknown))]
+    public enum WorkingDaysAllowAdditionalValues
+    {
+        Monday,
+        Tuesday,
+        Wednesday,
+        Thursday,
+        Friday,
+        _Unknown
+    }
 }

--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -75,7 +75,6 @@ namespace APIMatic.Core.Test.Utilities
             Assert.AreEqual(expected, actual);
         }
 
-
         [Test]
         public void JsonSerialize_CustomAttributeClass()
         {
@@ -137,6 +136,16 @@ namespace APIMatic.Core.Test.Utilities
         public void JsonSerialize_EnumNumberAllowUnknownEnumValues()
         {
             Assert.Throws<JsonSerializationException>(() => CoreHelper.JsonSerialize(MonthNumberAllowAdditionalValues._Unknown));
+        }
+
+        [Test]
+        public void JsonSerialize_EnumNumber()
+        {
+            var testEnum = MonthNumber.January;
+            Assert.That(CoreHelper.JsonSerialize(testEnum), Is.EqualTo("1"));
+
+            var testEnumRelaxed = MonthNumberAllowAdditionalValues.January;
+            Assert.That(CoreHelper.JsonSerialize(testEnumRelaxed), Is.EqualTo("1"));
         }
 
         #endregion
@@ -210,11 +219,14 @@ namespace APIMatic.Core.Test.Utilities
         [Test]
         public void JsonDeserialize_EnumNumber()
         {
+            var actual = CoreHelper.JsonDeserialize<MonthNumber>("3");
+            Assert.AreEqual(MonthNumber.March, actual);
+
             var actualNullable = CoreHelper.JsonDeserialize<MonthNumber?>("3");
             Assert.AreEqual(MonthNumber.March, actualNullable);
 
-            var actual = CoreHelper.JsonDeserialize<MonthNumber>("3");
-            Assert.AreEqual(MonthNumber.March, actual);
+            var actualAdditional = CoreHelper.JsonDeserialize<MonthNumberAllowAdditionalValues>("3");
+            Assert.AreEqual(MonthNumberAllowAdditionalValues.March, actualAdditional);
         }
 
         [Test]
@@ -229,6 +241,13 @@ namespace APIMatic.Core.Test.Utilities
         {
             var actual = CoreHelper.JsonDeserialize<MonthNumberAllowAdditionalValues>("\"-1\"");
             Assert.AreEqual(MonthNumberAllowAdditionalValues._Unknown, actual);
+        }
+
+        [Test]
+        public void JsonDeserialize_EnumNumberAllowUnknownEnumValuesNullable()
+        {
+            var actual = CoreHelper.JsonDeserialize<MonthNumberAllowAdditionalValues?>("null");
+            Assert.AreEqual(null, actual);
         }
 
         #endregion

--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -217,6 +217,13 @@ namespace APIMatic.Core.Test.Utilities
         }
 
         [Test]
+        public void JsonDeserialize_EnumStringAllowUnknownEnumValuesResponseContainsUnknown()
+        {
+            var actual = CoreHelper.JsonDeserialize<WorkingDaysAllowAdditionalValues>("\"_Unknown\"");
+            Assert.AreEqual(WorkingDaysAllowAdditionalValues._Unknown, actual);
+        }
+
+        [Test]
         public void JsonDeserialize_EnumNumber()
         {
             var actual = CoreHelper.JsonDeserialize<MonthNumber>("3");
@@ -955,6 +962,24 @@ namespace APIMatic.Core.Test.Utilities
             ServerResponse actual = CoreHelper.DeepCloneObject(expected);
             Assert.AreEqual(expected, actual);
         }
+        #endregion
+
+        #region Converters
+
+        [Test]
+        public void UnknownEnumConverter_CannotConvertEnumWithoutUnknownValue()
+        {
+            var converter = new UnknownEnumConverter<StringEnumConverter>("_Unknown");
+            Assert.That(converter.CanConvert(typeof(WorkingDays)), Is.False);
+        }
+
+        [Test]
+        public void UnknownEnumConverter_CanConvertEnumWithUnknownValue()
+        {
+            var converter = new UnknownEnumConverter<StringEnumConverter>("_Unknown");
+            Assert.That(converter.CanConvert(typeof(WorkingDaysAllowAdditionalValues)), Is.True);
+        }
+
         #endregion
     }
 }

--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -9,6 +9,7 @@ using APIMatic.Core.Test.MockTypes.Utilities;
 using APIMatic.Core.Utilities;
 using APIMatic.Core.Utilities.Converters;
 using APIMatic.Core.Utilities.Date;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 
@@ -126,6 +127,18 @@ namespace APIMatic.Core.Test.Utilities
             Assert.That(actual, Is.EquivalentTo(expected));
         }
 
+        [Test]
+        public void JsonSerialize_EnumStringAllowUnknownEnumValues()
+        {
+            Assert.Throws<JsonSerializationException>(() => CoreHelper.JsonSerialize(WorkingDaysAllowAdditionalValues._Unknown));
+        }
+
+        [Test]
+        public void JsonSerialize_EnumNumberAllowUnknownEnumValues()
+        {
+            Assert.Throws<JsonSerializationException>(() => CoreHelper.JsonSerialize(MonthNumberAllowAdditionalValues._Unknown));
+        }
+
         #endregion
 
         #region Deserialize
@@ -188,6 +201,13 @@ namespace APIMatic.Core.Test.Utilities
         }
 
         [Test]
+        public void JsonDeserialize_EnumStringAllowUnknownEnumValues()
+        {
+            var actual = CoreHelper.JsonDeserialize<WorkingDaysAllowAdditionalValues>("\"InvalidString\"");
+            Assert.AreEqual(WorkingDaysAllowAdditionalValues._Unknown, actual);
+        }
+
+        [Test]
         public void JsonDeserialize_EnumNumber()
         {
             var actualNullable = CoreHelper.JsonDeserialize<MonthNumber?>("3");
@@ -202,6 +222,13 @@ namespace APIMatic.Core.Test.Utilities
         {
             var actual = CoreHelper.JsonDeserialize<MonthNumber?>("null");
             Assert.AreEqual(null, actual);
+        }
+
+        [Test]
+        public void JsonDeserialize_EnumNumberAllowUnknownEnumValues()
+        {
+            var actual = CoreHelper.JsonDeserialize<MonthNumberAllowAdditionalValues>("\"-1\"");
+            Assert.AreEqual(MonthNumberAllowAdditionalValues._Unknown, actual);
         }
 
         #endregion

--- a/APIMatic.Core/Utilities/Converters/UnknownEnumConverter.cs
+++ b/APIMatic.Core/Utilities/Converters/UnknownEnumConverter.cs
@@ -5,13 +5,11 @@ namespace APIMatic.Core.Utilities.Converters
 {
     public class UnknownEnumConverter<T> : JsonConverter where T : JsonConverter, new()
     {
-        private readonly Type _type;
         private readonly string _unknownValue;
         private readonly T _innerJsonConverter;
 
-        public UnknownEnumConverter(Type type, string unknownValue)
+        public UnknownEnumConverter(string unknownValue)
         {
-            _type = type;
             _unknownValue = unknownValue;
             _innerJsonConverter = new T();
         }
@@ -34,7 +32,7 @@ namespace APIMatic.Core.Utilities.Converters
                 value = Convert.ToInt32(value);
             }
 
-            if (!Enum.IsDefined(objectType, value) && Enum.IsDefined(objectType, _unknownValue))
+            if (!Enum.IsDefined(objectType, value))
             {
                 return Enum.Parse(objectType, _unknownValue);
             }
@@ -44,9 +42,11 @@ namespace APIMatic.Core.Utilities.Converters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            if (value.ToString() == _unknownValue)
+            var enumType = value.GetType();
+
+            if (Enum.GetName(enumType, value) == _unknownValue)
             {
-                throw new JsonSerializationException($"{_type}.{value} is not a valid enum value for serialization!");
+                throw new JsonSerializationException($"{enumType.FullName}.{value} is not a valid enum value for serialization!");
             }
 
             _innerJsonConverter.WriteJson(writer, value, serializer);

--- a/APIMatic.Core/Utilities/Converters/UnknownEnumConverter.cs
+++ b/APIMatic.Core/Utilities/Converters/UnknownEnumConverter.cs
@@ -14,10 +14,7 @@ namespace APIMatic.Core.Utilities.Converters
             _innerJsonConverter = new T();
         }
 
-        public override bool CanConvert(Type objectType)
-        {
-            return _innerJsonConverter.CanConvert(objectType);
-        }
+        public override bool CanConvert(Type objectType) => _innerJsonConverter.CanConvert(objectType);
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {

--- a/APIMatic.Core/Utilities/Converters/UnknownEnumConverter.cs
+++ b/APIMatic.Core/Utilities/Converters/UnknownEnumConverter.cs
@@ -10,11 +10,14 @@ namespace APIMatic.Core.Utilities.Converters
 
         public UnknownEnumConverter(string unknownValue)
         {
-            _unknownValue = unknownValue;
+            _unknownValue = unknownValue ?? throw new ArgumentNullException(nameof(unknownValue));
             _innerJsonConverter = new T();
         }
 
-        public override bool CanConvert(Type objectType) => _innerJsonConverter.CanConvert(objectType);
+        public override bool CanConvert(Type objectType)
+        {
+            return Enum.IsDefined(objectType, _unknownValue) && _innerJsonConverter.CanConvert(objectType);
+        }
 
         public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
         {

--- a/APIMatic.Core/Utilities/Converters/UnknownEnumConverter.cs
+++ b/APIMatic.Core/Utilities/Converters/UnknownEnumConverter.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace APIMatic.Core.Utilities.Converters
+{
+    public class UnknownEnumConverter<T> : JsonConverter where T : JsonConverter, new()
+    {
+        private readonly Type _type;
+        private readonly string _unknownValue;
+        private readonly T _innerJsonConverter;
+
+        public UnknownEnumConverter(Type type, string unknownValue)
+        {
+            _type = type;
+            _unknownValue = unknownValue;
+            _innerJsonConverter = new T();
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return _innerJsonConverter.CanConvert(objectType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+
+            object value = reader.Value;
+            if (reader.TokenType == JsonToken.Integer)
+            {
+                value = Convert.ToInt32(value);
+            }
+
+            if (!Enum.IsDefined(objectType, value) && Enum.IsDefined(objectType, _unknownValue))
+            {
+                return Enum.Parse(objectType, _unknownValue);
+            }
+
+            return _innerJsonConverter.ReadJson(reader, objectType, existingValue, serializer);
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value.ToString() == _unknownValue)
+            {
+                throw new JsonSerializationException($"{_type}.{value} is not a valid enum value for serialization!");
+            }
+
+            _innerJsonConverter.WriteJson(writer, value, serializer);
+        }
+    }
+}


### PR DESCRIPTION
## Why
In order to be able to relax enum validation during deserialization, we had two options:
1. We can make the enum property nullable in the SDK so that when we deserialize the response and it doesn't match any existing enum value, it assigns null.
2. We can add a new special enum value (like _Unknown) in the SDK so that when we deserialize the response and it doesn't match any existing enum value, it assigns that special enum value.

Since `nullable` properties already have a set meaning, it wouldn't make sense to cause confusion by giving `null` yet another purpose. The second option allows us to be more explicit about what we mean when we allow any unknown values during deserialization.

Therefore, the second option has been implemented.

## What
- Added new type of `JsonConverter` to gracefully handle cases where we get unexpected enum values in the response
- Added tests for the new `JsonConverter`

Closes #65 

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [x] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
