### PR TITLE
feat: adds handling for missing content with unit tests

### DIFF
--- a/APIMatic.Core.Test/Api/HttpGet/ApiCallGetTest.cs
+++ b/APIMatic.Core.Test/Api/HttpGet/ApiCallGetTest.cs
@@ -675,6 +675,25 @@ namespace APIMatic.Core.Test.Api.HttpGet
         }
 
         [Test]
+        public void ApiCall_GetNullableNumber_WhiteSpaceContent()
+        {
+            //Arrange
+            var url = "/apicall/get/nullableNumber/whiteSpacedContent";
+
+            handlerMock.When(GetCompleteUrl(url))
+                .Respond(HttpStatusCode.NoContent, new StringContent("  "));
+
+            var apiCall = CreateSimpleApiCall<int?>()
+                .RequestBuilder(requestBuilderAction => requestBuilderAction.Setup(HttpMethod.Get, url))
+                .ResponseHandler(resHandlerAction => resHandlerAction.Deserializer(res => int.Parse(res)))
+                .ExecuteAsync();
+
+            // Act and Assert
+            var actual = CoreHelper.RunTask(apiCall);
+            Assert.Null(actual);
+        }
+
+        [Test]
         public void ApiCall_GetNullableNumber_WithContent()
         {
             //Arrange

--- a/APIMatic.Core.Test/Api/HttpGet/ApiCallGetTest.cs
+++ b/APIMatic.Core.Test/Api/HttpGet/ApiCallGetTest.cs
@@ -597,7 +597,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
 
             // Act and Assert
             var actual = CoreHelper.RunTask(apiCall);
-
             Assert.Null(actual);
         }
 
@@ -606,7 +605,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
         {
             //Arrange
             var url = "/apicall/get/model/missingContent";
-            var expected = new Dictionary<string, object>();
 
             handlerMock.When(GetCompleteUrl(url))
                 .Respond(HttpStatusCode.NoContent, new ByteArrayContent(Array.Empty<byte>()));
@@ -617,7 +615,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
 
             // Act and Assert
             var actual = CoreHelper.RunTask(apiCall);
-
             Assert.Null(actual);
         }
 
@@ -626,7 +623,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
         {
             //Arrange
             var url = "/apicall/get/string/missingContent";
-            var expected = new Dictionary<string, object>();
 
             handlerMock.When(GetCompleteUrl(url))
                 .Respond(HttpStatusCode.NoContent, new ByteArrayContent(Array.Empty<byte>()));
@@ -637,7 +633,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
 
             // Act and Assert
             var actual = CoreHelper.RunTask(apiCall);
-
             Assert.Null(actual);
         }
 
@@ -646,7 +641,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
         {
             //Arrange
             var url = "/apicall/get/number/missingContent";
-            var expected = new Dictionary<string, object>();
 
             handlerMock.When(GetCompleteUrl(url))
                 .Respond(HttpStatusCode.NoContent, new ByteArrayContent(Array.Empty<byte>()));
@@ -666,7 +660,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
         {
             //Arrange
             var url = "/apicall/get/nullableNumber/missingContent";
-            var expected = new Dictionary<string, object>();
 
             handlerMock.When(GetCompleteUrl(url))
                 .Respond(HttpStatusCode.NoContent, new ByteArrayContent(Array.Empty<byte>()));
@@ -678,7 +671,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
 
             // Act and Assert
             var actual = CoreHelper.RunTask(apiCall);
-
             Assert.Null(actual);
         }
 
@@ -687,7 +679,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
         {
             //Arrange
             var url = "/apicall/get/nullableNumber/withContent";
-            var expected = new Dictionary<string, object>();
 
             handlerMock.When(GetCompleteUrl(url))
                 .Respond(HttpStatusCode.OK, new StringContent("123"));
@@ -699,7 +690,6 @@ namespace APIMatic.Core.Test.Api.HttpGet
 
             // Act and Assert
             var actual = CoreHelper.RunTask(apiCall);
-
             Assert.AreEqual(123, actual);
         }
     }

--- a/APIMatic.Core.Test/Api/HttpGet/ApiCallGetTest.cs
+++ b/APIMatic.Core.Test/Api/HttpGet/ApiCallGetTest.cs
@@ -600,5 +600,107 @@ namespace APIMatic.Core.Test.Api.HttpGet
 
             Assert.Null(actual);
         }
+
+        [Test]
+        public void ApiCall_GetModel_MissingContent()
+        {
+            //Arrange
+            var url = "/apicall/get/model/missingContent";
+            var expected = new Dictionary<string, object>();
+
+            handlerMock.When(GetCompleteUrl(url))
+                .Respond(HttpStatusCode.NoContent, new ByteArrayContent(Array.Empty<byte>()));
+
+            var apiCall = CreateSimpleApiCall<ServerResponse>()
+                .RequestBuilder(requestBuilderAction => requestBuilderAction.Setup(HttpMethod.Get, url))
+                .ExecuteAsync();
+
+            // Act and Assert
+            var actual = CoreHelper.RunTask(apiCall);
+
+            Assert.Null(actual);
+        }
+
+        [Test]
+        public void ApiCall_GetString_MissingContent()
+        {
+            //Arrange
+            var url = "/apicall/get/string/missingContent";
+            var expected = new Dictionary<string, object>();
+
+            handlerMock.When(GetCompleteUrl(url))
+                .Respond(HttpStatusCode.NoContent, new ByteArrayContent(Array.Empty<byte>()));
+
+            var apiCall = CreateSimpleApiCall<string>()
+                .RequestBuilder(requestBuilderAction => requestBuilderAction.Setup(HttpMethod.Get, url))
+                .ExecuteAsync();
+
+            // Act and Assert
+            var actual = CoreHelper.RunTask(apiCall);
+
+            Assert.Null(actual);
+        }
+
+        [Test]
+        public void ApiCall_GetNumber_MissingContent()
+        {
+            //Arrange
+            var url = "/apicall/get/number/missingContent";
+            var expected = new Dictionary<string, object>();
+
+            handlerMock.When(GetCompleteUrl(url))
+                .Respond(HttpStatusCode.NoContent, new ByteArrayContent(Array.Empty<byte>()));
+
+            var apiCall = CreateSimpleApiCall<int>()
+                .RequestBuilder(requestBuilderAction => requestBuilderAction.Setup(HttpMethod.Get, url))
+                .ResponseHandler(resHandlerAction => resHandlerAction.Deserializer(res => int.Parse(res)))
+                .ExecuteAsync();
+
+            // Act and Assert
+            var exp = Assert.Throws<FormatException>(() => CoreHelper.RunTask(apiCall));
+            Assert.AreEqual("Input string was not in a correct format.", exp.Message);
+        }
+
+        [Test]
+        public void ApiCall_GetNullableNumber_MissingContent()
+        {
+            //Arrange
+            var url = "/apicall/get/nullableNumber/missingContent";
+            var expected = new Dictionary<string, object>();
+
+            handlerMock.When(GetCompleteUrl(url))
+                .Respond(HttpStatusCode.NoContent, new ByteArrayContent(Array.Empty<byte>()));
+
+            var apiCall = CreateSimpleApiCall<int?>()
+                .RequestBuilder(requestBuilderAction => requestBuilderAction.Setup(HttpMethod.Get, url))
+                .ResponseHandler(resHandlerAction => resHandlerAction.Deserializer(res => int.Parse(res)))
+                .ExecuteAsync();
+
+            // Act and Assert
+            var actual = CoreHelper.RunTask(apiCall);
+
+            Assert.Null(actual);
+        }
+
+        [Test]
+        public void ApiCall_GetNullableNumber_WithContent()
+        {
+            //Arrange
+            var url = "/apicall/get/nullableNumber/withContent";
+            var expected = new Dictionary<string, object>();
+
+            handlerMock.When(GetCompleteUrl(url))
+                .Respond(HttpStatusCode.OK, new StringContent("123"));
+
+            var apiCall = CreateSimpleApiCall<int?>()
+                .RequestBuilder(requestBuilderAction => requestBuilderAction.Setup(HttpMethod.Get, url))
+                .ResponseHandler(resHandlerAction => resHandlerAction.Deserializer(res => int.Parse(res)))
+                .ExecuteAsync();
+
+            // Act and Assert
+            var actual = CoreHelper.RunTask(apiCall);
+
+            Assert.AreEqual(123, actual);
+        }
     }
 }

--- a/APIMatic.Core.Test/TestBase.cs
+++ b/APIMatic.Core.Test/TestBase.cs
@@ -5,8 +5,6 @@ using APIMatic.Core.Authentication;
 using APIMatic.Core.Http.Configuration;
 using APIMatic.Core.Test.MockTypes.Authentication;
 using APIMatic.Core.Types;
-using APIMatic.Core.Utilities.Logger.Configuration;
-using Microsoft.Extensions.Logging.Abstractions;
 using RichardSzalay.MockHttp;
 
 namespace APIMatic.Core.Test

--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -6,6 +6,7 @@ using System.Text;
 using APIMatic.Core.Http.Configuration;
 using APIMatic.Core.Test.MockTypes.Models;
 using APIMatic.Core.Test.MockTypes.Utilities;
+using APIMatic.Core.Types;
 using APIMatic.Core.Utilities;
 using APIMatic.Core.Utilities.Converters;
 using APIMatic.Core.Utilities.Date;
@@ -988,6 +989,39 @@ namespace APIMatic.Core.Test.Utilities
             Assert.That(converter.CanConvert(typeof(WorkingDaysAllowAdditionalValues)), Is.True);
         }
 
+        #endregion
+
+        #region Others
+
+        [Test]
+        public void IsNullableType_AllTypes()
+        {
+            Assert.That(CoreHelper.IsNullableType(typeof(WorkingDays)), Is.False);
+            Assert.That(CoreHelper.IsNullableType(typeof(WorkingDays?)), Is.True);
+
+            Assert.That(CoreHelper.IsNullableType(typeof(DateTime)), Is.False);
+            Assert.That(CoreHelper.IsNullableType(typeof(DateTime?)), Is.True);
+
+            Assert.That(CoreHelper.IsNullableType(typeof(void)), Is.False);
+            Assert.That(CoreHelper.IsNullableType(typeof(VoidType)), Is.True);
+
+            Assert.That(CoreHelper.IsNullableType(typeof(int)), Is.False);
+            Assert.That(CoreHelper.IsNullableType(typeof(int?)), Is.True);
+            Assert.That(CoreHelper.IsNullableType(typeof(Nullable<int>)), Is.True);
+
+            Assert.That(CoreHelper.IsNullableType(typeof(double)), Is.False);
+            Assert.That(CoreHelper.IsNullableType(typeof(double?)), Is.True);
+            Assert.That(CoreHelper.IsNullableType(typeof(Nullable<double>)), Is.True);
+
+            Assert.That(CoreHelper.IsNullableType(typeof(bool)), Is.False);
+            Assert.That(CoreHelper.IsNullableType(typeof(bool?)), Is.True);
+            Assert.That(CoreHelper.IsNullableType(typeof(Nullable<bool>)), Is.True);
+
+            Assert.That(CoreHelper.IsNullableType(typeof(string)), Is.True);
+            Assert.That(CoreHelper.IsNullableType(typeof(ServerResponse)), Is.True);
+            Assert.That(CoreHelper.IsNullableType(typeof(List<object>)), Is.True);
+            Assert.That(CoreHelper.IsNullableType(typeof(Dictionary<string, object>)), Is.True);
+        }
         #endregion
     }
 }

--- a/APIMatic.Core/Response/ResponseHandler.cs
+++ b/APIMatic.Core/Response/ResponseHandler.cs
@@ -125,6 +125,10 @@ namespace APIMatic.Core.Response
             {
                 return default;
             }
+            if (CoreHelper.IsNullableType(typeof(ResponseType)) && IsBodyMissing(context.Response))
+            {
+                return default;
+            }
             ResponseType result = ConvertResponse(context.Response);
             result = contextAdder(result, compatibilityFactory.CreateHttpContext(context.Request, context.Response));
             if (result is ReturnType convertedResult)
@@ -137,6 +141,8 @@ namespace APIMatic.Core.Response
             }
             throw new InvalidOperationException($"Unable to transform {typeof(ResponseType)} into {typeof(ReturnType)}. ReturnTypeCreator is not provided.");
         }
+
+        private bool IsBodyMissing(CoreResponse response) => string.Equals(response.Body, string.Empty);
 
         private ApiException ResponseError(CoreContext<CoreRequest, CoreResponse> context)
         {

--- a/APIMatic.Core/Response/ResponseHandler.cs
+++ b/APIMatic.Core/Response/ResponseHandler.cs
@@ -145,7 +145,7 @@ namespace APIMatic.Core.Response
             {
                 return true;
             }
-            return string.Equals(response.Body, string.Empty) && CoreHelper.IsNullableType(resType);
+            return string.Equals(response.Body?.Trim(), string.Empty) && CoreHelper.IsNullableType(resType);
         }
 
         private ApiException ResponseError(CoreContext<CoreRequest, CoreResponse> context)

--- a/APIMatic.Core/Response/ResponseHandler.cs
+++ b/APIMatic.Core/Response/ResponseHandler.cs
@@ -121,11 +121,7 @@ namespace APIMatic.Core.Response
                 }
                 throw ResponseError(context);
             }
-            if (typeof(ResponseType) == typeof(VoidType))
-            {
-                return default;
-            }
-            if (CoreHelper.IsNullableType(typeof(ResponseType)) && IsBodyMissing(context.Response))
+            if (HasEmptyResponse(context.Response))
             {
                 return default;
             }
@@ -142,7 +138,15 @@ namespace APIMatic.Core.Response
             throw new InvalidOperationException($"Unable to transform {typeof(ResponseType)} into {typeof(ReturnType)}. ReturnTypeCreator is not provided.");
         }
 
-        private bool IsBodyMissing(CoreResponse response) => string.Equals(response.Body, string.Empty);
+        private bool HasEmptyResponse(CoreResponse response)
+        {
+            var resType = typeof(ResponseType);
+            if (resType == typeof(VoidType))
+            {
+                return true;
+            }
+            return string.Equals(response.Body, string.Empty) && CoreHelper.IsNullableType(resType);
+        }
 
         private ApiException ResponseError(CoreContext<CoreRequest, CoreResponse> context)
         {

--- a/APIMatic.Core/Utilities/CoreHelper.cs
+++ b/APIMatic.Core/Utilities/CoreHelper.cs
@@ -172,6 +172,12 @@ namespace APIMatic.Core.Utilities
             return Type.GetTypeCode(type) != TypeCode.Object || type == typeof(VoidType);
         }
 
+        internal static bool IsNullableType(Type type)
+        {
+            // Check if it's a reference type or a nullable value type
+            return !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
+        }
+
         /// <summary>
         /// Prepares parameters for serialization as a form encoded string by flattening complex Types such as Collections and Models to a list of KeyValuePairs, where each value is a string representation of the original Type.
         /// </summary>


### PR DESCRIPTION
## What
This PR adds complete support for returning nullable response types using the nullability check of the generic `ResponseType` to set the response types as nullable when content is missing.

## Why
Previously response handler was throwing an exception when a response with no content is received.

Closes #72 

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [X] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
Unit tests were added to test this feature

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added new unit tests
