### PR TITLE
fix(request-content-type): use provided content type in case of null body

### DIFF
--- a/APIMatic.Core.Test/Api/HttpPost/ApiCallPostTest.cs
+++ b/APIMatic.Core.Test/Api/HttpPost/ApiCallPostTest.cs
@@ -494,5 +494,42 @@ namespace APIMatic.Core.Test.Api.HttpPost
             Assert.NotNull(actual.Data);
             Assert.AreEqual(actual.Data.Message, expected.Message);
         }
+        
+        [Test]
+        public void ApiCall_PostNullBodyValue_OKResponse()
+        {
+            //Arrange
+            const string text = "Post null Body value.";
+            const string url = "/apicall/null-body-post/200";
+
+            var expected = new ServerResponse()
+            {
+                Message = text,
+                Passed = true,
+            };
+
+            var content = JsonContent.Create(expected);
+            handlerMock.When(GetCompleteUrl(url))
+                .With(req =>
+                {
+                    Assert.AreEqual("application/json", req.Content?.Headers.ContentType?.MediaType);
+                    return true;
+                })
+                .Respond(HttpStatusCode.OK, content);
+
+            var apiCall = CreateApiCall<ServerResponse>()
+                .RequestBuilder(requestBuilderAction => requestBuilderAction
+                    .Setup(HttpMethod.Post, url)
+                    .Parameters(p => p
+                        .Header(h => h.Setup("content-type", "application/json"))))
+                .ExecuteAsync();
+
+            // Act
+            var actual = CoreHelper.RunTask(apiCall);
+
+            // Assert
+            Assert.NotNull(actual);
+            Assert.AreEqual((int)HttpStatusCode.OK, actual.StatusCode);
+        }
     }
 }

--- a/APIMatic.Core/Request/RequestBuilder.cs
+++ b/APIMatic.Core/Request/RequestBuilder.cs
@@ -209,7 +209,7 @@ namespace APIMatic.Core.Request
             {
                 return false;
             }
-            if (headers.Any(p => p.Key.Equals(key, StringComparison.InvariantCultureIgnoreCase)))
+            if (headers.Any(p => p.Key.EqualsIgnoreCase(key)))
             {
                 return false;
             }

--- a/APIMatic.Core/Types/Sdk/CoreRequest.cs
+++ b/APIMatic.Core/Types/Sdk/CoreRequest.cs
@@ -1,6 +1,7 @@
 ﻿// <copyright file="CoreRequest.cs" company="APIMatic">
 // Copyright (c) APIMatic. All rights reserved.
 // </copyright>
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -82,6 +83,13 @@ namespace APIMatic.Core.Types.Sdk
         internal bool HasBinaryResponse { get; set; }
 
         /// <summary>
+        /// Gets a value indicating whether the request is likely to have form content.
+        /// This is determined by checking if the <see cref="Body"/> is null 
+        /// and if the <see cref="FormParameters"/> collection is not null and contains any items.
+        /// </summary>
+        internal bool HasFormParameters => Body == null && FormParameters != null && FormParameters.Any();
+        
+        /// <summary>
         /// Concatenate values from a Dictionary to this object.
         /// </summary>
         /// <param name="headersToAdd"> headersToAdd. </param>
@@ -103,6 +111,25 @@ namespace APIMatic.Core.Types.Sdk
                 ?? new Dictionary<string, object>(queryParamaters);
         }
 
+        /// <summary>
+        /// Retrieves the value of the "Content-Type" header from the request headers.
+        /// </summary>
+        /// <returns>
+        /// The value of the "Content-Type" header if present; otherwise, <c>null</c>.
+        /// </returns>
+        internal string GetContentType() => Headers?.Where(p => p.Key.EqualsIgnoreCase("content-type"))
+            .Select(x => x.Value)
+            .FirstOrDefault();
+        
+        /// <summary>
+        /// Converts the body of the request to a string representation.
+        /// </summary>
+        /// <returns>
+        /// The string representation of the <see cref="Body"/> if it is not <c>null</c>;
+        /// otherwise, returns an empty string.
+        /// </returns>
+        internal string GetBodyAsString() => Body == null ? String.Empty : Body.ToString();
+        
         /// <inheritdoc/>
         public override string ToString()
         {

--- a/APIMatic.Core/Utilities/StringExtensions.cs
+++ b/APIMatic.Core/Utilities/StringExtensions.cs
@@ -1,0 +1,15 @@
+﻿// <copyright file="StringExtensions.cs" company="APIMatic">
+// Copyright (c) APIMatic. All rights reserved.
+// </copyright>
+using System;
+
+namespace APIMatic.Core.Utilities
+{
+    internal static class StringExtensions
+    {
+        public static bool EqualsIgnoreCase(this string source, string target)
+        {
+            return source.Equals(target, StringComparison.InvariantCultureIgnoreCase);
+        }
+    }
+}


### PR DESCRIPTION
## What
The following PR fixes an issue where incorrect content type was being sent in the Request when body is set to null.

## Why
To fix HTTP 422 status code on ApiCall with null body.

Closes #74

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Testing
Tested the ApiCall with null body on ApiServer.

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
