### PR TITLE
fix: void type handling with return type creator

### DIFF
--- a/APIMatic.Core.Test/Api/HttpGet/ApiCallGetTest.cs
+++ b/APIMatic.Core.Test/Api/HttpGet/ApiCallGetTest.cs
@@ -384,6 +384,33 @@ namespace APIMatic.Core.Test.Api.HttpGet
         }
 
         [Test]
+        public void ApiCall_GetVoid_WithApiResponse()
+        {
+            //Arrange
+            var url = "/apicall/get-void/api-response/200";
+
+            var content = JsonContent.Create("Test body");
+            handlerMock.When(GetCompleteUrl(url))
+                .With(req =>
+                {
+                    Assert.AreEqual(0, req.Headers.Accept.Count);
+                    return true;
+                })
+                .Respond(HttpStatusCode.OK, content);
+
+            var apiCall = CreateApiCall<VoidType>()
+                .RequestBuilder(requestBuilderAction => requestBuilderAction.Setup(HttpMethod.Get, url))
+                .ExecuteAsync();
+
+            // Act
+            var actual = CoreHelper.RunTask(apiCall);
+
+            // Assert
+            Assert.IsInstanceOf<ApiResponse<VoidType>>(actual);
+            Assert.Null(actual.Data);
+        }
+
+        [Test]
         public void ApiCall_GetStream()
         {
             //Arrange


### PR DESCRIPTION
## What
This PR fixes a bug where VoidType was being returned instead of ApiResponse<VoidType>. It handles it via return type creator.

## Why
To improve coverage of void return type cases

Closes #76 

## Type of change
Select multiple if applicable.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
N/A

## Breaking change
N/A

## Testing
Unit tests are added to test these changes

## Checklist
- [X] My code follows the coding conventions
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added new unit tests
