### PR TITLE
fix(request-form): add handling for additional properties

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -196,6 +196,10 @@ csharp_style_namespace_declarations = block_scoped:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
 
+[APIMatic.Core/Utilities/CoreHelper.cs]
+# Disables S3011 rule (Reflection should not be used to increase accessibility)
+dotnet_diagnostic.S3011.severity = none
+
 [*.vb]
 ###############################
 # VB Coding Conventions       #

--- a/APIMatic.Core.Test/MockTypes/Models/SimpleModelWithAdditionalPropertiesBaseModel.cs
+++ b/APIMatic.Core.Test/MockTypes/Models/SimpleModelWithAdditionalPropertiesBaseModel.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace APIMatic.Core.Test.MockTypes.Models
+{
+    public class SimpleModelWithAdditionalPropertiesBaseModel : AdditionalPropertiesBaseModel
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleModelWithAdditionalPropertiesBaseModel"/> class.
+        /// </summary>
+        /// <param name="requiredProperty">requiredProperty.</param>
+        public SimpleModelWithAdditionalPropertiesBaseModel(
+            string requiredProperty)
+        {
+            this.RequiredProperty = requiredProperty;
+        }
+
+        /// <summary>
+        /// The required property
+        /// </summary>
+        [JsonProperty("requiredProperty")]
+        public string RequiredProperty { get; set; }
+    }
+
+    /// <summary>
+    /// BaseModel.
+    /// </summary>
+    public class AdditionalPropertiesBaseModel
+    {
+        /// <summary>
+        /// Gets or sets a dictionary holding all the additional properties.
+        /// </summary>
+        [JsonExtensionData]
+        public Dictionary<string, object> AdditionalProperties { get; set; }
+    }
+}

--- a/APIMatic.Core.Test/MockTypes/Models/SimpleModelWithAdditionalPropertiesField.cs
+++ b/APIMatic.Core.Test/MockTypes/Models/SimpleModelWithAdditionalPropertiesField.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -15,6 +16,7 @@ namespace APIMatic.Core.Test.MockTypes.Models
         /// <summary>
         /// Set the value associated with the specified key in the AdditionalProperties dictionary.
         /// </summary>
+        [IndexerName("AdditionalPropertiesIndexer")]
         public string this[string key]
         {
             set => _additionalProperties.SetValue(key, value);

--- a/APIMatic.Core.Test/MockTypes/Models/SimpleModelWithAdditionalPropertiesField.cs
+++ b/APIMatic.Core.Test/MockTypes/Models/SimpleModelWithAdditionalPropertiesField.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace APIMatic.Core.Test.MockTypes.Models
+{
+    public class SimpleModelWithAdditionalPropertiesField
+    {
+        [JsonExtensionData]
+        private readonly IDictionary<string, JToken> _additionalProperties;
+
+        /// <summary>
+        /// Set the value associated with the specified key in the AdditionalProperties dictionary.
+        /// </summary>
+        public string this[string key]
+        {
+            set => _additionalProperties.SetValue(key, value);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SimpleModelWithAdditionalPropertiesBaseModel"/> class.
+        /// </summary>
+        /// <param name="requiredProperty">requiredProperty.</param>
+        public SimpleModelWithAdditionalPropertiesField(
+            string requiredProperty)
+        {
+            this._additionalProperties = new Dictionary<string, JToken>();
+            this.RequiredProperty = requiredProperty;
+        }
+
+        /// <summary>
+        /// The required property
+        /// </summary>
+        [JsonProperty("requiredProperty")]
+        public string RequiredProperty { get; set; }
+    }
+
+    internal static class AdditionalPropertiesExtensions
+    {
+        internal static void SetValue(this IDictionary<string, JToken> additionalProperties, string key, object value)
+        {
+            additionalProperties[key] = JToken.FromObject(value);
+        }
+    }
+}

--- a/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
+++ b/APIMatic.Core.Test/Utilities/CoreHelperTest.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 using APIMatic.Core.Http.Configuration;
 using APIMatic.Core.Test.MockTypes.Models;
@@ -961,6 +962,59 @@ namespace APIMatic.Core.Test.Utilities
             List<KeyValuePair<string, object>> actual = CoreHelper.PrepareFormFieldsFromObject("jsonValue", jsonValue, ArraySerialization.Indexed);
             Assert.AreEqual(expected, actual);
         }
+
+        [Test]
+        public void PrepareFormFieldsFromObject_WithAdditionalPropertiesAsField()
+        {
+            var queryBuilder = new StringBuilder();
+            queryBuilder.Append(SERVER_URL);
+            var simpleModelWithAdditionalPropertiesField =
+                new SimpleModelWithAdditionalPropertiesField("Required Field")
+                {
+                    ["additionalPropertyKey"] = "additionalPropertyValue"
+                };
+
+            List<KeyValuePair<string, object>> expected = new List<KeyValuePair<string, object>>()
+            {
+                new("simpleModelWithAdditionalPropertiesField[requiredProperty]", "Required Field"),
+                new("simpleModelWithAdditionalPropertiesField[additionalPropertyKey]", "additionalPropertyValue")
+            };
+
+            List<KeyValuePair<string, object>> actual = CoreHelper.PrepareFormFieldsFromObject(
+                "simpleModelWithAdditionalPropertiesField", simpleModelWithAdditionalPropertiesField,
+                ArraySerialization.Indexed);
+
+            Assert.AreEqual(expected, actual);
+        }
+
+        [Test]
+        public void PrepareFormFieldsFromObject_WithAdditionalPropertiesBaseModel()
+        {
+            var queryBuilder = new StringBuilder();
+            queryBuilder.Append(SERVER_URL);
+            var simpleModelWithAdditionalPropertiesBaseModel =
+                new SimpleModelWithAdditionalPropertiesBaseModel("Required Field")
+                {
+                    AdditionalProperties =
+                        new Dictionary<string, object> { { "additionalPropertyKey", "additionalPropertyValue" } }
+                };
+
+            List<KeyValuePair<string, object>> expected = new List<KeyValuePair<string, object>>()
+            {
+                new("simpleModelWithAdditionalPropertiesBaseModel[requiredProperty]", "Required Field"),
+                new("simpleModelWithAdditionalPropertiesBaseModel[additionalPropertyKey]", "additionalPropertyValue")
+            };
+
+            List<KeyValuePair<string, object>> actual = CoreHelper.PrepareFormFieldsFromObject(
+                "simpleModelWithAdditionalPropertiesBaseModel", simpleModelWithAdditionalPropertiesBaseModel,
+                ArraySerialization.Indexed);
+
+            // Assert that all items in 'expected' are found within 'actual'
+            bool containsAllExpectedEntries = expected.All(item => actual.Contains(item));
+            Assert.IsTrue(containsAllExpectedEntries, "Not all expected entries are present in actual.");
+
+        }
+
         #endregion
 
         #region DeepCloneObject

--- a/APIMatic.Core/Utilities/CoreHelper.cs
+++ b/APIMatic.Core/Utilities/CoreHelper.cs
@@ -323,24 +323,28 @@ namespace APIMatic.Core.Utilities
             switch (additionalProperties)
             {
                 case IDictionary<string, JToken> additionalPropertiesJToken:
-                    foreach (var kvp in additionalPropertiesJToken)
-                    {
-                        string fullSubName = string.IsNullOrWhiteSpace(name) ? kvp.Key : $"{name}[{kvp.Key}]";
-                        PrepareFormFieldsFromObject(fullSubName, kvp.Value, arraySerializationFormat, keys, null);
-                    }
+                    HandleAdditionalProperties(additionalPropertiesJToken, name, arraySerializationFormat, keys);
                     return;
 
                 case IDictionary<string, object> additionalPropertiesObj:
-                    foreach (var kvp in additionalPropertiesObj)
-                    {
-                        string fullSubName = string.IsNullOrWhiteSpace(name) ? kvp.Key : $"{name}[{kvp.Key}]";
-                        PrepareFormFieldsFromObject(fullSubName, kvp.Value, arraySerializationFormat, keys, null);
-                    }
+                    HandleAdditionalProperties(additionalPropertiesObj, name, arraySerializationFormat, keys);
                     return;
             }
-
         }
-        private static void PrepareFormFieldsForDictionary(string name, IDictionary dictionary, ArraySerialization arraySerializationFormat, List<KeyValuePair<string, object>> keys = null, PropertyInfo propInfo = null)
+
+        private static void HandleAdditionalProperties<T>(IDictionary<string, T> properties, string name,
+            ArraySerialization arraySerializationFormat, List<KeyValuePair<string, object>> keys)
+        {
+            foreach (var kvp in properties)
+            {
+                string fullSubName = string.IsNullOrWhiteSpace(name) ? kvp.Key : $"{name}[{kvp.Key}]";
+                PrepareFormFieldsFromObject(fullSubName, kvp.Value, arraySerializationFormat, keys, null);
+            }
+        }
+
+        private static void PrepareFormFieldsForDictionary(string name, IDictionary dictionary,
+            ArraySerialization arraySerializationFormat, List<KeyValuePair<string, object>> keys = null,
+            PropertyInfo propInfo = null)
         {
             foreach (var sName in dictionary.Keys)
             {

--- a/APIMatic.Core/Utilities/CoreHelper.cs
+++ b/APIMatic.Core/Utilities/CoreHelper.cs
@@ -311,7 +311,10 @@ namespace APIMatic.Core.Utilities
                 .GetMembers(BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance)
                 .FirstOrDefault(member => member.GetCustomAttribute<JsonExtensionDataAttribute>() != null);
 
-            if (additionalPropertiesMember == null) return;
+            if (additionalPropertiesMember == null)
+            {
+                return;
+            }
 
             object additionalProperties = additionalPropertiesMember is FieldInfo fieldInfo
                 ? fieldInfo.GetValue(value)


### PR DESCRIPTION
## What
This PR addresses an issue with the handling of additional properties in models that use [JsonExtensionData]. Specifically, it ensures that additional properties are flattened along with the model’s main members when data is sent as form data. Previously, the additional properties were being sent as a nested dictionary in form data, causing inconsistencies between the form data and the JSON body representation.

## Why
Flattening the additional properties in form data ensures consistency between how data is represented in both the JSON body and form data formats. This alignment is important for APIs that process form data in a similar way to JSON payloads, ensuring the behavior is predictable and that consumers of the API receive a consistent structure. Additionally, this change improves compatibility with clients that expect all model properties, including those from [JsonExtensionData], to be at the top level.

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Testing
- Added unit tests to verify that models with additional properties, defined as both a property and a field, are correctly flattened when sent as form data.
- The tests include scenarios where:
  - Additional properties are included as part of a [JsonExtensionData] dictionary.
  - Form data correctly represents additional properties as flattened key-value pairs.
  - Consistency is maintained between the JSON body and form data outputs for models with [JsonExtensionData].
- These tests confirm that additional properties are no longer sent as nested dictionaries in form data.

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
