### PR TITLE
chore(deps): update Newtonsoft.Json to version range 13.0.*

### DIFF
--- a/APIMatic.Core/APIMatic.Core.csproj
+++ b/APIMatic.Core/APIMatic.Core.csproj
@@ -38,7 +38,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.*" />
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="APIMatic.Core.Test" />


### PR DESCRIPTION
## What
Changed `Newtonsoft.Json` version to a flexible range (13.0.*) to allow patch updates while maintaining compatibility.

## Why
Ensures the application benefits from minor bug fixes and updates without requiring manual intervention.

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [x] CI/Build (adds or updates a script, change in external dependencies)
