### PR TITLE
chore(deps): update Newtonsoft.Json to use version range

### DIFF
--- a/APIMatic.Core/APIMatic.Core.csproj
+++ b/APIMatic.Core/APIMatic.Core.csproj
@@ -38,7 +38,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.*" />
+        <PackageReference Include="Newtonsoft.Json" Version="[13.0.1,)" />
     </ItemGroup>
     <ItemGroup>
         <InternalsVisibleTo Include="APIMatic.Core.Test" />


### PR DESCRIPTION
Move Newtonsoft.Json dependency from wildcard to a version range to support Dependabot updates and maintain compatibility.
