### PR TITLE
fix(http-to-string): remove ToString() overrides

### DIFF
--- a/APIMatic.Core.Test/APIMatic.Core.Test.csproj
+++ b/APIMatic.Core.Test/APIMatic.Core.Test.csproj
@@ -19,7 +19,7 @@
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
         <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-        <PackageReference Include="System.Net.Http.Json" Version="7.0.1" />
+        <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/APIMatic.Core.Test/TypesTest.cs
+++ b/APIMatic.Core.Test/TypesTest.cs
@@ -63,34 +63,6 @@ namespace APIMatic.Core.Test
         }
 
         [Test]
-        public void HttpContext_String_Representation()
-        {
-            var response = new HttpResponse(200, new Dictionary<string, string>(), new MemoryStream(Encoding.UTF8.GetBytes("")), "Test body");
-            var request = new HttpRequest(HttpMethod.Get, "https://myurl.com");
-
-            request.AddHeaders(new Dictionary<string, string>
-            {
-                { "keyA1", "value A1"}
-            });
-            request.AddHeaders(new Dictionary<string, string>
-            {
-                { "keyA2", "value A2"}
-            });
-            request.AddQueryParameters(new Dictionary<string, object>
-            {
-                { "queryA1", "value A1"},
-            });
-            request.AddQueryParameters(new Dictionary<string, object>
-            {
-                { "queryA2", "value A2"}
-            });
-            var context = new HttpContext(request, response);
-
-            var expected = " Request =  HttpMethod = GET,  QueryUrl = https://myurl.com,  QueryParameters = {\"queryA1\":\"value A1\",\"queryA2\":\"value A2\"},  Headers = {\"keyA1\":\"value A1\",\"keyA2\":\"value A2\"},  FormParameters = ,  Body = ,  Username = ,  Password = , Response =  StatusCode = 200,  Headers = {} RawBody = System.IO.MemoryStream";
-            Assert.AreEqual(expected, context.ToString());
-        }
-
-        [Test]
         public void JsonObject_String_Representation()
         {
             var jsonObject = JsonObject.FromJsonString(null);

--- a/APIMatic.Core.Test/TypesTest.cs
+++ b/APIMatic.Core.Test/TypesTest.cs
@@ -96,5 +96,45 @@ namespace APIMatic.Core.Test
             var actualDeserialized = CoreHelper.JsonDeserialize<JsonValue>(expectedString);
             Assert.AreEqual(jsonValue.ToString(), actualDeserialized.ToString());
         }
+        
+        [Test]
+        public void AddHeaders_ShouldAddHeaders_WhenHeadersNotNull()
+        {
+            // Arrange
+            var coreRequest = new HttpRequest(HttpMethod.Get, "https://myurl.com");
+            var headersToAdd = new Dictionary<string, string>
+            {
+                { "Content-Type", "application/json" },
+                { "Authorization", "Bearer token" }
+            };
+
+            // Act
+            var result = coreRequest.AddHeaders(headersToAdd);
+
+            // Assert
+            Assert.AreEqual(2, result.Count);
+            Assert.AreEqual("application/json", result["Content-Type"]);
+            Assert.AreEqual("Bearer token", result["Authorization"]);
+        }
+        
+        [Test]
+        public void AddQueryParameters_ShouldAddQueryParameters_WhenQueryParametersAreNotNull()
+        {
+            // Arrange
+            var coreRequest = new HttpRequest(HttpMethod.Get, "https://myurl.com");
+            var queryParametersToAdd = new Dictionary<string, object>
+            {
+                { "search", "test" },
+                { "limit", 10 }
+            };
+
+            // Act
+            coreRequest.AddQueryParameters(queryParametersToAdd);
+
+            // Assert
+            Assert.AreEqual(2, coreRequest.QueryParameters.Count);
+            Assert.AreEqual("test", coreRequest.QueryParameters["search"]);
+            Assert.AreEqual(10, coreRequest.QueryParameters["limit"]);
+        }
     }
 }

--- a/APIMatic.Core/Types/Sdk/CoreContext.cs
+++ b/APIMatic.Core/Types/Sdk/CoreContext.cs
@@ -31,11 +31,5 @@ namespace APIMatic.Core.Types.Sdk
         public Res Response { get; }
 
         internal bool IsFailure() => (Response.StatusCode < 200) || (Response.StatusCode > 208);
-
-        /// <inheritdoc/>
-        public override string ToString()
-        {
-            return $" Request = {Request}, Response = {Response}";
-        }
     }
 }

--- a/APIMatic.Core/Types/Sdk/CoreRequest.cs
+++ b/APIMatic.Core/Types/Sdk/CoreRequest.cs
@@ -128,18 +128,5 @@ namespace APIMatic.Core.Types.Sdk
         /// otherwise, returns an empty string.
         /// </returns>
         internal string GetBodyAsString() => Body == null ? string.Empty : Body.ToString();
-        
-        /// <inheritdoc/>
-        public override string ToString()
-        {
-            return $" HttpMethod = {HttpMethod}, " +
-                $" QueryUrl = {QueryUrl}, " +
-                $" QueryParameters = {CoreHelper.JsonSerialize(QueryParameters)}, " +
-                $" Headers = {CoreHelper.JsonSerialize(Headers)}, " +
-                $" FormParameters = {CoreHelper.JsonSerialize(FormParameters)}, " +
-                $" Body = {Body}, " +
-                $" Username = {Username}, " +
-                $" Password = {Password}";
-        }
     }
 }

--- a/APIMatic.Core/Types/Sdk/CoreResponse.cs
+++ b/APIMatic.Core/Types/Sdk/CoreResponse.cs
@@ -41,13 +41,5 @@ namespace APIMatic.Core.Types.Sdk
         /// Gets the raw string body of the http response.
         /// </summary>
         public string Body { get; }
-
-        /// <inheritdoc/>
-        public override string ToString()
-        {
-            return $" StatusCode = {StatusCode}, " +
-                $" Headers = {CoreHelper.JsonSerialize(Headers)}" +
-                $" RawBody = {RawBody}";
-        }
     }
 }


### PR DESCRIPTION
## What
- Removed ToString() overrides from HttpContext, HttpRequest, and HttpResponse to prevent exposure of sensitive information.
- Bump package System.Net.Http.Json in test project due to reported vulnerability

## Why
ToString() overrides in HTTP-related classes (e.g., HttpContext, HttpRequest, HttpResponse) risk exposing sensitive information.

Closes #97

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)
