### PR TITLE
fix(client): prevent client freeze when calling async from sync methods

### DIFF
--- a/APIMatic.Core/ApiCall.cs
+++ b/APIMatic.Core/ApiCall.cs
@@ -102,7 +102,7 @@ namespace APIMatic.Core
         public async Task<ReturnType> ExecuteAsync(CancellationToken cancellationToken = default)
         {
             requestBuilder.AcceptHeader = responseHandler.AcceptHeader;
-            CoreRequest request = await requestBuilder.Build();
+            CoreRequest request = await requestBuilder.Build().ConfigureAwait(false);
             globalConfiguration.ApiCallback?.OnBeforeHttpRequestEventHandler(request);
             _sdkLogger.LogRequest(request);
             CoreResponse response = await globalConfiguration.HttpClient.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);

--- a/APIMatic.Core/Authentication/AuthGroupBuilder.cs
+++ b/APIMatic.Core/Authentication/AuthGroupBuilder.cs
@@ -118,7 +118,7 @@ namespace APIMatic.Core.Authentication
             Validate();
             foreach (var authManager in validatedAuthManagers)
             {
-                await authManager.Apply(requestBuilder);
+                await authManager.Apply(requestBuilder).ConfigureAwait(false);
             }
         }
     }

--- a/APIMatic.Core/Http/HttpClientWrapper.cs
+++ b/APIMatic.Core/Http/HttpClientWrapper.cs
@@ -74,7 +74,7 @@ namespace APIMatic.Core.Http
             if (_overrideHttpClientConfiguration)
             {
                 responseMessage = await GetCombinedPolicy(request.RetryOption).ExecuteAsync(
-                    async (cancellation) => await ExecuteHttpRequest(request, cancellation).ConfigureAwait(false), cancellationToken)
+                    async (cancellation) => await ExecuteHttpRequest(request, cancellation).ConfigureAwait(false), cancellationToken, false)
                     .ConfigureAwait(false);
             }
             else
@@ -286,7 +286,7 @@ namespace APIMatic.Core.Http
                             GetServerWaitDuration(result).TotalMilliseconds)),
                     onRetryAsync: async (result, timespan, retryAttempt, context) =>
                     {
-                        await Task.CompletedTask;
+                        await Task.CompletedTask.ConfigureAwait(false);
                     });
 
         private AsyncTimeoutPolicy GetTimeoutPolicy()

--- a/APIMatic.Core/Request/RequestBuilder.cs
+++ b/APIMatic.Core/Request/RequestBuilder.cs
@@ -150,7 +150,7 @@ namespace APIMatic.Core.Request
         {
             parameters.Validate().Apply(this);
             configuration.RuntimeParameters.Validate().Apply(this);
-            await authGroup.Apply(this);
+            await authGroup.Apply(this).ConfigureAwait(false);
             CoreHelper.AppendUrlWithQueryParameters(QueryUrl, queryParameters, ArraySerialization);
             body = bodyParameters.Any() ? bodyParameters : body;
             AppendContentTypeHeader();


### PR DESCRIPTION
## What
- Applied ConfigureAwait(false) to await calls in async methods.
- Ensured proper async handling to prevent UI or request thread blocking.

## Why
- Calling async methods from synchronous code without ConfigureAwait(false) can cause deadlocks, especially in UI or ASP.NET applications.
- This fix ensures that awaited tasks do not attempt to resume execution on the original synchronization context, preventing the client from freezing.

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Testing
The fix was tested using a C# client generated from an ASP.NET Web App targeting .NET Framework 4.8.
