### PR TITLE
fix(request-parameter): deduplicate parameters using ConcurrentDictionary

### DIFF
--- a/APIMatic.Core.Test/Request/ParameterTests.cs
+++ b/APIMatic.Core.Test/Request/ParameterTests.cs
@@ -1,0 +1,53 @@
+﻿using System.Threading.Tasks;
+using APIMatic.Core.Request;
+using APIMatic.Core.Request.Parameters;
+using NUnit.Framework;
+
+namespace APIMatic.Core.Test.Request
+{
+    [TestFixture]
+    public class ParameterTests : TestBase
+    {
+        const string ServerUrl = "https://parameter.api.server.com";
+        
+        [Test]
+        public void DuplicateHeaderKeys_Should_UseLastOneInRequestBuilder()
+        {
+            // Arrange
+            var parameters = new Parameter.Builder();
+
+            parameters
+                .Header(h => h.Setup("Authorization", "Basic OLD").Required())
+                .Header(h => h.Setup("Authorization", "Basic NEW").Required());
+
+            var requestBuilder = new RequestBuilder(LazyGlobalConfiguration.Value, ServerUrl);
+
+            // Act
+            parameters.Validate().Apply(requestBuilder);
+
+            // Assert
+            Assert.That(requestBuilder.headersParameters.TryGetValue("Authorization", out var value), Is.True);
+            Assert.That(value, Is.EqualTo("Basic NEW"));
+        }
+        
+        [Test]
+        public void DuplicateQueryKeys_Should_UseLastOneInRequestBuilder()
+        {
+            // Arrange
+            var parameters = new Parameter.Builder();
+
+            parameters
+                .Query(q => q.Setup("status", "pending").Required())
+                .Query(q => q.Setup("status", "approved").Required());
+
+            var requestBuilder = new RequestBuilder(LazyGlobalConfiguration.Value, ServerUrl);
+
+            // Act
+            parameters.Validate().Apply(requestBuilder);
+
+            // Assert
+            Assert.That(requestBuilder.queryParameters.TryGetValue("status", out var value), Is.True);
+            Assert.That(value, Is.EqualTo("approved"));
+        }
+    }
+}

--- a/APIMatic.Core.Test/Request/ParameterTests.cs
+++ b/APIMatic.Core.Test/Request/ParameterTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading.Tasks;
-using APIMatic.Core.Request;
+﻿using APIMatic.Core.Request;
 using APIMatic.Core.Request.Parameters;
 using NUnit.Framework;
 


### PR DESCRIPTION
## What
This PR replaces the internal parameter collection inside `Parameter.Builder` with a `ConcurrentDictionary<string, Parameter>`, using each parameter’s key as the dictionary key.

## Why
Previously, we used a `ConcurrentBag` to collect parameters, which:
- Caused duplicates when multiple parameters had the same key.
- Introduced ordering issues.
- Allowed stale values (e.g., expired tokens) to be reused unintentionally.

The new implementation:
- Ensures only one entry per parameter key (latest value wins).
- Resolves long-standing parameter accumulation issues across requests.
- Aligns with expected `AuthManager` behavior (i.e., always using the most recent token).
- Maintains thread safety while improving correctness.

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
