### PR TITLE
ci: migrate test coverage report to SonarQube

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,13 +36,11 @@ jobs:
 
     - name: Test & Coverage Collection
       if: ${{ matrix.os == 'ubuntu-22.04' && matrix.dotnet == '7.0.x' }}
-      run: dotnet test APIMatic.Core.Test/APIMatic.Core.Test.csproj -p:CollectCoverage=true -p:CoverletOutputFormat=lcov
-    
-    # - name: Upload coverage report
-    #   if: ${{ matrix.os == 'ubuntu-22.04' && matrix.dotnet == '7.0.x' && github.actor != 'dependabot[bot]' }}
-    #   uses: paambaati/codeclimate-action@v3.0.0
-    #   env:
-    #     CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_KEY }}
-    #   with:
-    #     coverageLocations: |
-    #       ${{github.workspace}}/APIMatic.Core.Test/coverage.info:lcov
+      run: dotnet test APIMatic.Core.Test/APIMatic.Core.Test.csproj -p:CollectCoverage=true -p:CoverletOutputFormat=opencover
+
+    - name: SonarQube Scan
+      if: ${{ github.actor != 'dependabot[bot]' && matrix.os == 'ubuntu-22.04' && matrix.dotnet == '7.0.x' }}
+      uses: SonarSource/sonarqube-scan-action@v5.2.0
+      env:
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Version][nuget-version]][nuget-url]
 [![Build & Tests][test-badge]][test-url]
 [![Test Coverage][coverage-badge]][coverage-url]
+[![Vulnerabilities][vulnerabilities-badge]][vulnerabilities-url]
 [![Maintainability][maintainability-badge]][maintainability-url]
 [![Licence][license-badge]][license-url]
 
@@ -44,13 +45,17 @@ This project contains core logic and the utilities for the APIMatic's C# SDK
 
 [test-url]: https://github.com/apimatic/core-lib-csharp/actions/workflows/test.yml
 
-[coverage-badge]: https://api.codeclimate.com/v1/badges/d613a5f73f605369e745/test_coverage
+[coverage-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-csharp&metric=coverage
 
-[coverage-url]: https://codeclimate.com/github/apimatic/core-lib-csharp/test_coverage
+[coverage-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-csharp
 
-[maintainability-badge]: https://api.codeclimate.com/v1/badges/d613a5f73f605369e745/maintainability
+[vulnerabilities-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-csharp&metric=vulnerabilities
 
-[maintainability-url]: https://codeclimate.com/github/apimatic/core-lib-csharp/maintainability
+[vulnerabilities-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-csharp
+
+[maintainability-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_core-lib-csharp&metric=sqale_rating
+
+[maintainability-url]: https://sonarcloud.io/summary/new_code?id=apimatic_core-lib-csharp
 
 [license-badge]: https://img.shields.io/badge/licence-MIT-blue
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.projectKey=apimatic_core-lib-csharp
+sonar.organization=apimatic
+sonar.projectName=APIMatic Core Library C\#
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=APIMatic.Core
+
+sonar.tests=APIMatic.Core.Test
+
+sonar.cs.opencover.reportsPaths=APIMatic.Core.Test/coverage.opencover.xml


### PR DESCRIPTION
## What
- Added SonarQube scan step to the GitHub Actions workflow
- Added SonarQube badges to the README

## Why
Replace CodeClimate with SonarQube for test coverage analysis.

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [x] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [ ] My code follows the coding conventions
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
