### PR TITLE
chore(bump-packages): update test project dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/APIMatic.Core.Test"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependency update"
+    commit-message:
+      prefix: "build"
+      include: "scope"
+    open-pull-requests-limit: 10
+    rebase-strategy: "auto"
+    reviewers:
+      - "asadali214"

--- a/APIMatic.Core.Test/APIMatic.Core.Test.csproj
+++ b/APIMatic.Core.Test/APIMatic.Core.Test.csproj
@@ -7,8 +7,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-        <PackageReference Include="coverlet.msbuild" Version="3.2.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+        <PackageReference Include="coverlet.msbuild" Version="6.0.4">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -17,9 +17,9 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="NUnit" Version="3.13.3" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
-        <PackageReference Include="RichardSzalay.MockHttp" Version="6.0.0" />
-        <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+        <PackageReference Include="RichardSzalay.MockHttp" Version="7.0.0" />
+        <PackageReference Include="System.Net.Http.Json" Version="10.0.2" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## What
- Updated the package version in the test project
- Configured dependabot.yml to run only in the APIMatic.Core.Test directory

## Why
- Ensures the test project uses the correct package version
- Limits Dependabot updates to the relevant test directory, reducing unnecessary CI activity
